### PR TITLE
Edit HomePage Url to custom domain

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "bugs": {
     "url": "https://github.com/dodoongtak/show-me-the-money/issues"
   },
-  "homepage": "https://github.com/dodoongtak/show-me-the-money#readme",
+  "homepage": "https://howmuchmore.xyz",
   "devDependencies": {
     "@babel/core": "^7.9.6",
     "@babel/preset-env": "^7.9.6",


### PR DESCRIPTION
In [the documentation](https://create-react-app.dev/docs/deployment/#github-pages), it states that the homepage URL must be matched with the one deployed.

Hope it works. 

![image](https://user-images.githubusercontent.com/77006427/112728497-ef5bac80-8f6a-11eb-9d98-09a1aeea87a8.png)
