### PR TITLE
📦 use react-hook-form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8995,6 +8995,11 @@
         "scheduler": "^0.20.2"
       }
     },
+    "react-hook-form": {
+      "version": "6.15.5",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-6.15.5.tgz",
+      "integrity": "sha512-so2jEPYKdVk1olMo+HQ9D9n1hVzaPPFO4wsjgSeZ964R7q7CHsYRbVF0PGBi83FcycA5482WHflasdwLIUVENg=="
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@reduxjs/toolkit": "^1.5.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-hook-form": "^6.15.5",
     "react-redux": "^7.2.3",
     "react-router-dom": "^5.2.0",
     "redux": "^4.0.5"


### PR DESCRIPTION
Install [react-hook-form](https://react-hook-form.com/) dependency.

To handle the controlled components easier, I chose react-hook-form, the 3rd party library.

To be advised, it isn't the best one, but still good at handling controlled components.

If problem-related to handling uncontrolled component arises will consider looking for
another library in the future.

See also:
- https://react-hook-form.com/get-started