### PR TITLE
👷 build: redirect to index.html on routing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Lint
         run: npm run lint
       - run: npm run build
-      - run: mv -t ./dist/ ./404.html
+      - run: mv -t ./dist/ ./index.html ./404.html
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
Assume `?p=` appears on URL due to missing index.html. 