### PR TITLE
🐛fix: prevent anchor default event

### DIFF
--- a/src/components/LinkField.jsx
+++ b/src/components/LinkField.jsx
@@ -1,11 +1,16 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 
 export default function LinkField({ url, title, onClick }) {
+  const handleClick = useCallback((event) => {
+    event.preventDefault();
+    onClick({ url });
+  }, [onClick]);
+
   return (
     <div>
       <a
         href={url}
-        onClick={() => onClick({ url })}
+        onClick={handleClick}
       >
         {title}
       </a>


### PR DESCRIPTION
Anchor default event refreshes the site.

This may be the cause of all issues regarding routing on deployed sever.