### PR TITLE
Make Apartment link public

### DIFF
--- a/src/screens/HomeScreen/Home.jsx
+++ b/src/screens/HomeScreen/Home.jsx
@@ -16,12 +16,6 @@ export default function Home({ profile, onClick }) {
           title="내 정보 확인하러가기"
           onClick={onClick}
         />
-
-        <LinkField
-          url="/apartment/riverside"
-          title="거주하고 싶은 아파트 둘러보기"
-          onClick={onClick}
-        />
       </>
     );
   }
@@ -31,11 +25,19 @@ export default function Home({ profile, onClick }) {
       <h2>꿈꾸는 삶을 살기 위해 얼마나 많은 돈을 더 벌어야 될까요?</h2>
       {
         profile?.isNew && (
-          <LinkField
-            url="/profile/new"
-            title="내 정보 입력하러가기"
-            onClick={onClick}
-          />
+          <>
+            <LinkField
+              url="/profile/new"
+              title="내 정보 입력하러가기"
+              onClick={onClick}
+            />
+
+            <LinkField
+              url="/apartment/riverside"
+              title="거주하고 싶은 아파트 둘러보기"
+              onClick={onClick}
+            />
+          </>
         )
       }
     </div>

--- a/src/screens/HomeScreen/Home.test.jsx
+++ b/src/screens/HomeScreen/Home.test.jsx
@@ -40,6 +40,16 @@ describe('Home', () => {
 
       expect(handleClick).toBeCalledTimes(1);
     });
+
+    it('calls handleClick upon clicking check apartments', () => {
+      renderHome();
+
+      fireEvent.click(screen.getByRole('link', {
+        name: '거주하고 싶은 아파트 둘러보기',
+      }));
+
+      expect(handleClick).toBeCalledTimes(1);
+    });
   });
 
   context('with profile', () => {
@@ -61,16 +71,6 @@ describe('Home', () => {
 
       fireEvent.click(screen.getByRole('link', {
         name: '내 정보 확인하러가기',
-      }));
-
-      expect(handleClick).toBeCalledTimes(1);
-    });
-
-    it('calls handleClick upon clicking check apartments', () => {
-      renderHome();
-
-      fireEvent.click(screen.getByRole('link', {
-        name: '거주하고 싶은 아파트 둘러보기',
       }));
 
       expect(handleClick).toBeCalledTimes(1);


### PR DESCRIPTION
Users without a profile can now see the apartment link.

If they want to see the apartment's result, they will be redirected new profile screen to fill-up the form.

![image](https://user-images.githubusercontent.com/77006427/113445795-832ced00-9431-11eb-8f85-5f4406df748e.png)
