### PR TITLE
Wrap anchor with button element in LinkField

### DIFF
--- a/src/components/LinkField.jsx
+++ b/src/components/LinkField.jsx
@@ -8,12 +8,14 @@ export default function LinkField({ url, title, onClick }) {
 
   return (
     <div>
-      <a
-        href={url}
-        onClick={handleClick}
-      >
-        {title}
-      </a>
+      <button type="button">
+        <a
+          href={url}
+          onClick={handleClick}
+        >
+          {title}
+        </a>
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
Since anchor is an inline element, it would require extra styling lines. 