### PR TITLE
🔥 Remove: unnecessary exact on route

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -37,7 +37,7 @@ export default function App() {
         <Switch>
           <Route exact path="/" component={HomePage} />
           <Route exact path="/profile" component={ProfilePage} />
-          <Route exact path="/profile/new" component={NewProfilePage} />
+          <Route path="/profile/new" component={NewProfilePage} />
           <Route exact path="/apartment" component={ApartmentPage} />
           <Route path="/apartment/:id" component={ApartmentPage} />
           <Route component={NotFoundPage} />


### PR DESCRIPTION
Use 'exact' prop when it is needed.

See also:
- https://reactrouter.com/web/api/Route