### PR TITLE
✅ test: add scenario for testing fetchApartments returns list of apartments

### DIFF
--- a/src/redux/appSlice.test.js
+++ b/src/redux/appSlice.test.js
@@ -134,6 +134,21 @@ describe('loadApartments', () => {
     const actions = store.getActions();
 
     expect(actions[0]).toEqual(setApartment([]));
-    expect(actions[1]).toEqual(setApartment([]));
+    expect(actions[1]).toEqual(setApartment([
+      {
+        name: '아크로리버파크',
+        date: '2021-03',
+        area: '129.92',
+        price: '470,000',
+        lotNumber: 1,
+      },
+      {
+        name: '서울',
+        date: '2021-02',
+        area: '200.27',
+        price: '420,000',
+        lotNumber: 2,
+      },
+    ]));
   });
 });

--- a/src/services/__mocks__/api.js
+++ b/src/services/__mocks__/api.js
@@ -1,5 +1,20 @@
 export async function fetchApartments() {
-  return [];
+  return [
+    {
+      name: '아크로리버파크',
+      date: '2021-03',
+      area: '129.92',
+      price: '470,000',
+      lotNumber: 1,
+    },
+    {
+      name: '서울',
+      date: '2021-02',
+      area: '200.27',
+      price: '420,000',
+      lotNumber: 2,
+    },
+  ];
 }
 
 // TODO: TO BE DELETED

--- a/src/services/api.test.js
+++ b/src/services/api.test.js
@@ -1,14 +1,8 @@
-// import { fetchApartments } from './api';
+import { fetchApartments } from './api';
 
-// jest.mock('./api');
+jest.mock('./api');
 
 describe('api', () => {
-  const mockFetch = (data) => {
-    global.fetch = jest.fn().mockResolvedValue({
-      async json() { return data; },
-    });
-  };
-
   const APARTMENTS = [
     {
       name: '아크로리버파크',
@@ -27,24 +21,12 @@ describe('api', () => {
   ];
 
   describe('fetchApartments', () => {
-    beforeEach(() => {
-      mockFetch(APARTMENTS);
-    });
-
-    // WOKR IN PROGRESS
-    // The test below does not execute mockFetch method.
-    // Even though mockFetch and api mock file is provided,
-    // It does request to get true response from deployed server, not mockfetched data.
-    // This sabotages the test's speed. So Commented Out at this point.
-
-    // If jest.mock(./api) is written at top, it does not return mockFetchData neither.
-
     it('returns apartments', async () => {
-      // const apartments = await fetchApartments({ apartmentCategory: 'riverside' });
+      const apartments = await fetchApartments({ apartmentCategory: 'riverside' });
 
-      // expect(apartments).toEqual(APARTMENTS);
-      // expect(apartments[0].아파트).toEqual(APARTMENTS[0].아파트);
-      // expect(apartments[1].아파트).toEqual(APARTMENTS[1].아파트);
+      expect(apartments).toEqual(APARTMENTS);
+      expect(apartments[0].name).toEqual(APARTMENTS[0].name);
+      expect(apartments[1].name).toEqual(APARTMENTS[1].name);
     });
   });
 });


### PR DESCRIPTION
Delete MockFetch since requesting data is handled by Axios. 

The purpose of API testing is to see if it returns the list of apartments, not real data acquired from the end point.