### PR TITLE
✨ feat: Show Apartment Details on Result Page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -39,8 +39,8 @@ export default function App() {
           <Route exact path="/" component={HomePage} />
           <Route exact path="/profile" component={ProfilePage} />
           <Route path="/profile/new" component={NewProfilePage} />
-          <Route exact path="/apartment" component={ApartmentPage} />
-          <Route path="/apartment/:id" component={ApartmentPage} />
+          <Route exact path="/apartments" component={ApartmentPage} />
+          <Route path="/apartments/:id" component={ApartmentPage} />
           <Route exact path="/result" component={ResultPage} />
           <Route component={NotFoundPage} />
         </Switch>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import {
   ProfilePage,
   NewProfilePage,
   ApartmentPage,
+  ResultPage,
   NotFoundPage,
 } from './pages';
 
@@ -40,6 +41,7 @@ export default function App() {
           <Route path="/profile/new" component={NewProfilePage} />
           <Route exact path="/apartment" component={ApartmentPage} />
           <Route path="/apartment/:id" component={ApartmentPage} />
+          <Route exact path="/result" component={ResultPage} />
           <Route component={NotFoundPage} />
         </Switch>
       </main>

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -18,6 +18,7 @@ describe('App', () => {
   const dispatch = jest.fn();
 
   const profile = {
+    isNew: false,
     name: '신형탁',
     age: 29,
     salary: 5000,
@@ -41,7 +42,18 @@ describe('App', () => {
     },
   ];
 
+  const apartment = {
+    name: '아크로리버파크',
+    date: '2021-03',
+    district: '반포동',
+    area: '129.92',
+    price: '470,000',
+    lotNumber: 1,
+  };
+
+  given('userFields', () => (profile));
   given('apartments', () => apartments);
+  given('apartment', () => apartment);
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -51,6 +63,7 @@ describe('App', () => {
     useSelector.mockImplementation((selector) => selector({
       userFields: given.userFields,
       apartments: given.apartments,
+      apartment: given.apartment,
     }));
 
     loadItem.mockImplementation(() => null);
@@ -65,8 +78,6 @@ describe('App', () => {
   }
 
   context('with path /', () => {
-    given('userFields', () => (profile));
-
     beforeEach(() => {
       loadItem.mockImplementation(() => (JSON.stringify(profile)));
     });
@@ -79,8 +90,6 @@ describe('App', () => {
   });
 
   context('with path /profile/new', () => {
-    given('userFields', () => (profile));
-
     it('renders new profile page', () => {
       renderApp({ path: '/profile/new' });
 
@@ -95,8 +104,6 @@ describe('App', () => {
   });
 
   context('with path /profile', () => {
-    given('userFields', () => (profile));
-
     it('renders profile page', () => {
       renderApp({ path: '/profile' });
 
@@ -120,6 +127,18 @@ describe('App', () => {
       renderApp({ path: '/apartment/riverside' });
 
       expect(screen.getByText('아크로리버파크')).toBeInTheDocument();
+    });
+  });
+
+  context('with path /result', () => {
+    it('renders the apartment result page', () => {
+      renderApp({ path: '/result' });
+
+      expect(screen.getByText('결과')).toBeInTheDocument();
+
+      expect(screen.getByText('아크로리버파크')).toBeInTheDocument();
+      expect(screen.getByText('129.92')).toBeInTheDocument();
+      expect(screen.getByText('470,000')).toBeInTheDocument();
     });
   });
 

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -114,17 +114,17 @@ describe('App', () => {
     });
   });
 
-  context('with path /aparment', () => {
+  context('with path /aparments', () => {
     it('renders apartment page', () => {
-      renderApp({ path: '/apartment' });
+      renderApp({ path: '/apartments' });
 
       expect(screen.getByText('거주하고 싶은신 아파트를 선택해주세요')).toBeInTheDocument();
     });
   });
 
-  context('with path /apartment/:id', () => {
+  context('with path /apartments/:id', () => {
     it('redners the apartment page', () => {
-      renderApp({ path: '/apartment/riverside' });
+      renderApp({ path: '/apartments/riverside' });
 
       expect(screen.getByText('아크로리버파크')).toBeInTheDocument();
     });

--- a/src/components/LinkField.jsx
+++ b/src/components/LinkField.jsx
@@ -1,8 +1,13 @@
 import React, { useCallback } from 'react';
 
-export default function LinkField({ url, title, onClick }) {
+export default function LinkField({
+  url, title, onClick, apartment, changeApartment,
+}) {
   const handleClick = useCallback((event) => {
     event.preventDefault();
+    if (title === '보기') {
+      changeApartment(apartment);
+    }
     onClick({ url });
   }, [onClick]);
 

--- a/src/components/LinkField.test.jsx
+++ b/src/components/LinkField.test.jsx
@@ -32,7 +32,7 @@ describe('LinkField', () => {
     it('calls handleClick upon clicking link', () => {
       render((
         <LinkField
-          url="/apartment"
+          url="/apartments"
           title="거주하고 싶은 아파트 둘러보기"
           onClick={handleClick}
         />
@@ -42,14 +42,14 @@ describe('LinkField', () => {
         name: '거주하고 싶은 아파트 둘러보기',
       }));
 
-      expect(handleClick).toBeCalledWith({ url: '/apartment' });
+      expect(handleClick).toBeCalledWith({ url: '/apartments' });
     });
   });
 
   context("with '보기' title", () => {
     render((
       <LinkField
-        url="/apartment"
+        url="/apartments"
         title="보기"
         onClick={handleClick}
         apartment={{

--- a/src/components/LinkField.test.jsx
+++ b/src/components/LinkField.test.jsx
@@ -6,38 +6,68 @@ import LinkField from './LinkField';
 
 describe('LinkField', () => {
   const handleClick = jest.fn();
+  const changeApartment = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('renders Link', () => {
-    render((
-      <LinkField
-        url="/profile/new"
-        title="내 정보 입력하러가기"
-        onClick={handleClick}
-      />
-    ));
+  context("with '내 정보 입력하러가기' title", () => {
+    it('renders Link', () => {
+      render((
+        <LinkField
+          url="/profile/new"
+          title="내 정보 입력하러가기"
+          onClick={handleClick}
+        />
+      ));
 
-    expect(screen.getByRole('link', {
-      name: '내 정보 입력하러가기',
-    })).toBeInTheDocument();
+      expect(screen.getByRole('link', {
+        name: '내 정보 입력하러가기',
+      })).toBeInTheDocument();
+    });
   });
 
-  it('calls handleClick upon clicking link', () => {
+  context("with '거주하고 싶은 아파트 둘러보기' title", () => {
+    it('calls handleClick upon clicking link', () => {
+      render((
+        <LinkField
+          url="/apartment"
+          title="거주하고 싶은 아파트 둘러보기"
+          onClick={handleClick}
+        />
+      ));
+
+      fireEvent.click(screen.getByRole('link', {
+        name: '거주하고 싶은 아파트 둘러보기',
+      }));
+
+      expect(handleClick).toBeCalledWith({ url: '/apartment' });
+    });
+  });
+
+  context("with '보기' title", () => {
     render((
       <LinkField
         url="/apartment"
-        title="거주하고 싶은 아파트 둘러보기"
+        title="보기"
         onClick={handleClick}
+        apartment={{
+          name: '아크로리버파크',
+          date: '2021-03',
+          area: '129.92',
+          price: '470,000',
+          lotNumber: 1,
+        }}
+        changeApartment={changeApartment}
       />
     ));
 
     fireEvent.click(screen.getByRole('link', {
-      name: '거주하고 싶은 아파트 둘러보기',
+      name: '보기',
     }));
 
-    expect(handleClick).toBeCalledWith({ url: '/apartment' });
+    expect(handleClick).toBeCalled();
+    expect(changeApartment).toBeCalled();
   });
 });

--- a/src/pages/Apartment/Apartment.jsx
+++ b/src/pages/Apartment/Apartment.jsx
@@ -1,26 +1,20 @@
 import React from 'react';
 
-export default function Apartment({ apartments }) {
-  if (!apartments.length) {
-    return (
-      <p>loading</p>
-    );
-  }
+export default function Apartment({ apartment }) {
+  const {
+    name,
+    district,
+    area,
+  } = apartment;
 
   return (
-    <>
-      {apartments?.map((apartment) => (
-        <div key={apartment.name}>
-          <dl>
-            <dd>아파트명:</dd>
-            <dt>{apartment.name}</dt>
-            <dd>법정동:</dd>
-            <dt>{apartment.district}</dt>
-            <dd>전용면적:</dd>
-            <dt>{apartment.area}</dt>
-          </dl>
-        </div>
-      ))}
-    </>
+    <dl>
+      <dd>아파트명:</dd>
+      <dt>{name}</dt>
+      <dd>법정동:</dd>
+      <dt>{district}</dt>
+      <dd>전용면적:</dd>
+      <dt>{area}</dt>
+    </dl>
   );
 }

--- a/src/pages/Apartment/Apartment.test.jsx
+++ b/src/pages/Apartment/Apartment.test.jsx
@@ -5,37 +5,20 @@ import { render, screen } from '@testing-library/react';
 import Apartment from './Apartment';
 
 describe('Apartment', () => {
-  const apartments = [
-    {
-      name: '아크로리버파크',
-      date: '2021-03',
-      area: '129.92',
-      price: '470,000',
-      lotNumber: 1,
-    },
-    {
-      name: '서울',
-      date: '2021-02',
-      area: '200.27',
-      price: '420,000',
-      lotNumber: 2,
-    },
-  ];
+  const apartment = {
+    name: '아크로리버파크',
+    date: '2021-03',
+    district: '반포동',
+    area: '129.92',
+    price: '470,000',
+    lotNumber: 1,
+  };
 
-  context('without apartments', () => {
-    it('renders loading', () => {
-      render(<Apartment apartments={[]} />);
+  it('renders apartment', () => {
+    render(<Apartment apartment={apartment} />);
 
-      expect(screen.getByText('loading')).toBeInTheDocument();
-    });
-  });
-
-  context('with apartments', () => {
-    it('renders Apartment Page', () => {
-      render(<Apartment apartments={apartments} />);
-
-      expect(screen.getByText('아크로리버파크')).toBeInTheDocument();
-      expect(screen.getByText('서울')).toBeInTheDocument();
-    });
+    expect(screen.getByText('아크로리버파크')).toBeInTheDocument();
+    expect(screen.getByText('반포동')).toBeInTheDocument();
+    expect(screen.getByText('129.92')).toBeInTheDocument();
   });
 });

--- a/src/pages/Apartment/ApartmentNavigation.jsx
+++ b/src/pages/Apartment/ApartmentNavigation.jsx
@@ -7,14 +7,14 @@ export default function ApartmentNavigation({ onClick }) {
       <ul>
         <li>
           <LinkField
-            url="/apartment/riverside"
+            url="/apartments/riverside"
             title="한강 뷰"
             onClick={onClick}
           />
         </li>
         <li>
           <LinkField
-            url="/apartment/businessdistrict"
+            url="/apartments/businessdistrict"
             title="우수 상권"
             onClick={onClick}
           />

--- a/src/pages/Apartment/ApartmentNavigation.test.jsx
+++ b/src/pages/Apartment/ApartmentNavigation.test.jsx
@@ -35,6 +35,6 @@ describe('ApartmentNavigation', () => {
       name: '한강 뷰',
     }));
 
-    expect(handleClick).toBeCalledWith({ url: '/apartment/riverside' });
+    expect(handleClick).toBeCalledWith({ url: '/apartments/riverside' });
   });
 });

--- a/src/pages/Apartment/ApartmentPage.jsx
+++ b/src/pages/Apartment/ApartmentPage.jsx
@@ -14,10 +14,13 @@ export default function ApartmentPage({ params }) {
   }, [history]);
 
   return (
-    <div>
-      <h2>거주하고 싶은신 아파트를 선택해주세요</h2>
+    <section>
+      <header>거주하고 싶은신 아파트를 선택해주세요</header>
       <ApartmentNavigation onClick={handleClick} />
-      <ApartmentContainer apartmentCategory={id} />
-    </div>
+      <ApartmentContainer
+        apartmentCategory={id}
+        onClick={handleClick}
+      />
+    </section>
   );
 }

--- a/src/pages/Apartment/Apartments.jsx
+++ b/src/pages/Apartment/Apartments.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+import LinkField from '../../components/LinkField';
+
+import Apartment from './Apartment';
+
+export default function Apartments({ apartments, onClick, changeApartment }) {
+  if (!apartments.length) {
+    return (
+      <p>loading</p>
+    );
+  }
+
+  return (
+    <>
+      {apartments?.map((apartment) => (
+        <article key={apartment.name}>
+          <Apartment apartment={apartment} />
+          <LinkField
+            url="/result"
+            title="보기"
+            onClick={onClick}
+            apartment={apartment}
+            changeApartment={changeApartment}
+          />
+        </article>
+      ))}
+    </>
+  );
+}

--- a/src/pages/Apartment/Apartments.test.jsx
+++ b/src/pages/Apartment/Apartments.test.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import Apartments from './Apartments';
+
+describe('Apartments', () => {
+  const handleClick = jest.fn();
+  const changeApartment = jest.fn();
+
+  const apartments = [
+    {
+      name: '아크로리버파크',
+      date: '2021-03',
+      area: '129.92',
+      price: '470,000',
+      lotNumber: 1,
+    },
+    {
+      name: '서울',
+      date: '2021-02',
+      area: '200.27',
+      price: '420,000',
+      lotNumber: 2,
+    },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  context('without apartments', () => {
+    it('renders loading', () => {
+      render(<Apartments apartments={[]} />);
+
+      expect(screen.getByText('loading')).toBeInTheDocument();
+    });
+  });
+
+  context('with apartments', () => {
+    it('renders Apartment Page', () => {
+      render(<Apartments apartments={apartments} />);
+
+      expect(screen.getByText('아크로리버파크')).toBeInTheDocument();
+      expect(screen.getByText('서울')).toBeInTheDocument();
+
+      expect(screen.getAllByText('보기')).toHaveLength(2);
+    });
+
+    it("calls handleClick upon clicking '보기' button", () => {
+      render(<Apartments
+        apartments={apartments}
+        onClick={handleClick}
+        apartment={apartments[0]}
+        changeApartment={changeApartment}
+      />);
+
+      fireEvent.click(screen.getAllByText('보기')[0]);
+
+      expect(handleClick).toBeCalledWith({ url: '/result' });
+    });
+  });
+});

--- a/src/pages/Apartment/ApartmentsContainer.jsx
+++ b/src/pages/Apartment/ApartmentsContainer.jsx
@@ -2,13 +2,13 @@ import React, { useEffect } from 'react';
 
 import { useDispatch, useSelector } from 'react-redux';
 
-import { loadApartments } from '../../redux/appSlice';
+import { loadApartments, setApartment } from '../../redux/appSlice';
 
 import { get } from '../../utils/utils';
 
-import Apartment from './Apartment';
+import Apartments from './Apartments';
 
-export default function Apartments({ apartmentCategory }) {
+export default function ApartmentContainer({ apartmentCategory, onClick }) {
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -17,10 +17,18 @@ export default function Apartments({ apartmentCategory }) {
 
   const apartments = useSelector(get('apartments'));
 
+  function changeApartment(apartment) {
+    dispatch(setApartment(apartment));
+  }
+
   return (
     <section>
-      {apartmentCategory}
-      <Apartment apartments={apartments} />
+      <header>{apartmentCategory}</header>
+      <Apartments
+        apartments={apartments}
+        onClick={onClick}
+        changeApartment={changeApartment}
+      />
     </section>
   );
 }

--- a/src/pages/Home/Greet.jsx
+++ b/src/pages/Home/Greet.jsx
@@ -23,15 +23,11 @@ export default function Greet({ profile, onClick }) {
   }
   return (
     <article>
-      {isNew && (
-        <>
-          <LinkField
-            url="/profile/new"
-            title="내 정보 입력하러가기"
-            onClick={onClick}
-          />
-        </>
-      )}
+      <LinkField
+        url="/profile/new"
+        title="내 정보 입력하러가기"
+        onClick={onClick}
+      />
     </article>
   );
 }

--- a/src/pages/Home/Greet.jsx
+++ b/src/pages/Home/Greet.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import LinkField from '../../components/LinkField';
+
+export default function Greet({ profile, onClick }) {
+  const { isNew, name } = profile;
+
+  if (!isNew) {
+    return (
+      <article>
+        <p>
+          {name}
+          님 안녕하세요!!
+        </p>
+
+        <LinkField
+          url="/profile"
+          title="내 정보 확인하러가기"
+          onClick={onClick}
+        />
+      </article>
+    );
+  }
+  return (
+    <article>
+      {isNew && (
+        <>
+          <LinkField
+            url="/profile/new"
+            title="내 정보 입력하러가기"
+            onClick={onClick}
+          />
+        </>
+      )}
+    </article>
+  );
+}

--- a/src/pages/Home/Greet.test.jsx
+++ b/src/pages/Home/Greet.test.jsx
@@ -1,0 +1,80 @@
+import React from 'react';
+
+import {
+  render,
+  screen,
+  fireEvent,
+} from '@testing-library/react';
+
+import given from 'given2';
+
+import { initialUserField } from '../../fixtures/initials';
+
+import Greet from './Greet';
+
+describe('Greet', () => {
+  const handleClick = jest.fn();
+
+  const profile = {
+    isNew: false,
+    name: '신형탁',
+    age: 29,
+    salary: 5000,
+    asset: 10000,
+  };
+
+  const renderGreet = () => render((
+    <Greet
+      profile={given.profile}
+      onClick={handleClick}
+    />
+  ));
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  context('without profile', () => {
+    given('profile', () => initialUserField);
+
+    it('renders a link for user to fill up to form', () => {
+      renderGreet();
+
+      expect(screen.getByText('내 정보 입력하러가기')).toBeInTheDocument();
+    });
+
+    it('calls handleClick upon clicking new profile', () => {
+      renderGreet();
+
+      fireEvent.click(screen.getByRole('link', {
+        name: '내 정보 입력하러가기',
+      }));
+
+      expect(handleClick).toBeCalledTimes(1);
+    });
+  });
+
+  context('with profile', () => {
+    given('profile', () => (profile));
+
+    it('renders user name', () => {
+      renderGreet();
+
+      expect(screen.getByText(/신형탁/)).toBeInTheDocument();
+
+      expect(screen.getByRole('link', {
+        name: '내 정보 확인하러가기',
+      })).toBeInTheDocument();
+    });
+
+    it('calls handleClick upon clicking check my profile', () => {
+      renderGreet();
+
+      fireEvent.click(screen.getByRole('link', {
+        name: '내 정보 확인하러가기',
+      }));
+
+      expect(handleClick).toBeCalledTimes(1);
+    });
+  });
+});

--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -17,7 +17,7 @@ export default function Home({ profile, onClick }) {
       )}
 
       <LinkField
-        url="/apartment/riverside"
+        url="/apartments/riverside"
         title="거주하고 싶은 아파트 둘러보기"
         onClick={onClick}
       />

--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -2,44 +2,25 @@ import React from 'react';
 
 import LinkField from '../../components/LinkField';
 
-export default function Home({ profile, onClick }) {
-  if (!profile.isNew) {
-    return (
-      <>
-        <p>
-          {profile.name}
-          님 안녕하세요!!
-        </p>
+import Greet from './Greet';
 
-        <LinkField
-          url="/profile"
-          title="내 정보 확인하러가기"
+export default function Home({ profile, onClick }) {
+  return (
+    <section>
+      <header>꿈꾸는 삶을 살기 위해 얼마나 많은 돈을 더 벌어야 될까요?</header>
+
+      {profile && (
+        <Greet
+          profile={profile}
           onClick={onClick}
         />
-      </>
-    );
-  }
+      )}
 
-  return (
-    <div>
-      <h2>꿈꾸는 삶을 살기 위해 얼마나 많은 돈을 더 벌어야 될까요?</h2>
-      {
-        profile?.isNew && (
-          <>
-            <LinkField
-              url="/profile/new"
-              title="내 정보 입력하러가기"
-              onClick={onClick}
-            />
-
-            <LinkField
-              url="/apartment/riverside"
-              title="거주하고 싶은 아파트 둘러보기"
-              onClick={onClick}
-            />
-          </>
-        )
-      }
-    </div>
+      <LinkField
+        url="/apartment/riverside"
+        title="거주하고 싶은 아파트 둘러보기"
+        onClick={onClick}
+      />
+    </section>
   );
 }

--- a/src/pages/Home/Home.test.jsx
+++ b/src/pages/Home/Home.test.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
 
-import { render, screen, fireEvent } from '@testing-library/react';
+import {
+  render,
+  screen,
+  fireEvent,
+} from '@testing-library/react';
 
 import given from 'given2';
-
-import { initialUserField } from '../../fixtures/initials';
 
 import Home from './Home';
 
@@ -22,58 +24,21 @@ describe('Home', () => {
     jest.clearAllMocks();
   });
 
-  context('without profile', () => {
-    given('profile', () => initialUserField);
+  it('renders a link for user to check apartments', () => {
+    renderHome();
 
-    it('renders Home Page', () => {
-      renderHome();
-
-      expect(screen.getByText('내 정보 입력하러가기')).toBeInTheDocument();
-    });
-
-    it('calls handleClick upon clicking new profile', () => {
-      renderHome();
-
-      fireEvent.click(screen.getByRole('link', {
-        name: '내 정보 입력하러가기',
-      }));
-
-      expect(handleClick).toBeCalledTimes(1);
-    });
-
-    it('calls handleClick upon clicking check apartments', () => {
-      renderHome();
-
-      fireEvent.click(screen.getByRole('link', {
-        name: '거주하고 싶은 아파트 둘러보기',
-      }));
-
-      expect(handleClick).toBeCalledTimes(1);
-    });
+    expect(screen.getByRole('link', {
+      name: '거주하고 싶은 아파트 둘러보기',
+    })).toBeInTheDocument();
   });
 
-  context('with profile', () => {
-    given('profile', () => ({
-      name: '신형탁',
-      age: 29,
-      salary: 5000,
-      asset: 10000,
+  it('calls handleClick upon clicking check apartments', () => {
+    renderHome();
+
+    fireEvent.click(screen.getByRole('link', {
+      name: '거주하고 싶은 아파트 둘러보기',
     }));
 
-    it('renders user name', () => {
-      renderHome();
-      expect(screen.getByText(/신형탁/)).toBeInTheDocument();
-      expect(screen.getByText('내 정보 확인하러가기')).toBeInTheDocument();
-    });
-
-    it('calls handleClick upon clicking check my profile', () => {
-      renderHome();
-
-      fireEvent.click(screen.getByRole('link', {
-        name: '내 정보 확인하러가기',
-      }));
-
-      expect(handleClick).toBeCalledTimes(1);
-    });
+    expect(handleClick).toBeCalledTimes(1);
   });
 });

--- a/src/pages/Profile/ProfilePage.jsx
+++ b/src/pages/Profile/ProfilePage.jsx
@@ -11,6 +11,8 @@ export default function ProfilePage() {
   }, [history]);
 
   return (
-    <ProfileContainer onClickNewProfile={handleClickNewProfile} />
+    <section>
+      <ProfileContainer onClickNewProfile={handleClickNewProfile} />
+    </section>
   );
 }

--- a/src/pages/Result/ApartmentDetail.jsx
+++ b/src/pages/Result/ApartmentDetail.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+
+export default function ApartmentDetail({ apartment }) {
+  const {
+    name,
+    area,
+    price,
+    date,
+    district,
+    lotNumber,
+  } = apartment;
+
+  return (
+    <>
+      <dl>
+        <dd>
+          아파트명:
+        </dd>
+        <dt>
+          {name}
+        </dt>
+
+        <dd>
+          전용면적:
+        </dd>
+        <dt>
+          {area}
+        </dt>
+
+        <dd>
+          거래금액:
+        </dd>
+        <dt>
+          {price}
+        </dt>
+
+        <dd>
+          매매일자:
+        </dd>
+        <dt>
+          {date}
+        </dt>
+
+        <dd>
+          법정동:
+        </dd>
+        <dt>
+          {district}
+        </dt>
+
+        <dd>
+          지번:
+        </dd>
+        <dt>
+          {lotNumber}
+        </dt>
+      </dl>
+    </>
+  );
+}

--- a/src/pages/Result/ApartmentDetail.test.jsx
+++ b/src/pages/Result/ApartmentDetail.test.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+import ApartmentDetail from './ApartmentDetail';
+
+describe('ApartmentDetail', () => {
+  const apartment = {
+    name: '아크로리버파크',
+    date: '2021-03',
+    district: '반포동',
+    area: '129.92',
+    price: '470,000',
+    lotNumber: 1,
+  };
+
+  it('renders apartment details', () => {
+    render(<ApartmentDetail apartment={apartment} />);
+
+    expect(screen.getByText('아크로리버파크')).toBeInTheDocument();
+    expect(screen.getByText('129.92')).toBeInTheDocument();
+    expect(screen.getByText('470,000')).toBeInTheDocument();
+    expect(screen.getByText('2021-03')).toBeInTheDocument();
+    expect(screen.getByText('반포동')).toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
+  });
+});

--- a/src/pages/Result/Result.jsx
+++ b/src/pages/Result/Result.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+import LinkField from '../../components/LinkField';
+
+import Profile from '../Profile/Profile';
+
+import ApartmentDetail from './ApartmentDetail';
+
+export default function Result({
+  profile, apartment, onClick, goBack,
+}) {
+  if (profile.isNew) {
+    return (
+      <>
+        <p>
+          정보를 아직 입력하지 않으셨습니다.
+        </p>
+        <LinkField
+          url="/profile/new"
+          title="내 정보 입력 하러가기"
+          onClick={onClick}
+        />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <LinkField
+        url="/apartment"
+        title="뒤로가기"
+        onClick={goBack}
+      />
+
+      {apartment
+        && (
+          <ApartmentDetail apartment={apartment} />
+        )}
+
+      <Profile
+        profile={profile}
+        onClickNewProfile={onClick}
+      />
+    </>
+  );
+}

--- a/src/pages/Result/Result.jsx
+++ b/src/pages/Result/Result.jsx
@@ -27,7 +27,7 @@ export default function Result({
   return (
     <>
       <LinkField
-        url="/apartment"
+        url="/apartments"
         title="뒤로가기"
         onClick={goBack}
       />

--- a/src/pages/Result/Result.test.jsx
+++ b/src/pages/Result/Result.test.jsx
@@ -74,7 +74,7 @@ describe('Result', () => {
         name: '뒤로가기',
       }));
 
-      expect(goBack).toBeCalledWith({ url: '/apartment' });
+      expect(goBack).toBeCalledWith({ url: '/apartments' });
     });
   });
 

--- a/src/pages/Result/Result.test.jsx
+++ b/src/pages/Result/Result.test.jsx
@@ -1,0 +1,103 @@
+import React from 'react';
+
+import {
+  fireEvent,
+  render,
+  screen,
+} from '@testing-library/react';
+
+import given from 'given2';
+
+import { initialUserField } from '../../fixtures/initials';
+
+import Result from './Result';
+
+describe('Result', () => {
+  const handleClick = jest.fn();
+  const goBack = jest.fn();
+
+  const profile = {
+    isNew: false,
+    name: '신형탁',
+    age: 29,
+    salary: 5000,
+    asset: 10000,
+  };
+
+  const apartment = {
+    name: '아크로리버파크',
+    date: '2021-03',
+    district: '반포동',
+    area: '129.92',
+    price: '470,000',
+    lotNumber: 1,
+  };
+
+  function renderResult() {
+    return render((
+      <Result
+        profile={given.profile}
+        apartment={apartment}
+        onClick={handleClick}
+        goBack={goBack}
+      />
+    ));
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  context('with profile', () => {
+    given('profile', () => profile);
+
+    it('renders Result', () => {
+      renderResult();
+
+      expect(screen.getByText('아크로리버파크')).toBeInTheDocument();
+      expect(screen.getByText('129.92')).toBeInTheDocument();
+      expect(screen.getByText('470,000')).toBeInTheDocument();
+      expect(screen.getByText('2021-03')).toBeInTheDocument();
+      expect(screen.getByText('반포동')).toBeInTheDocument();
+      expect(screen.getByText('1')).toBeInTheDocument();
+
+      expect(screen.getByText('신형탁')).toBeInTheDocument();
+      expect(screen.getByText('29')).toBeInTheDocument();
+      expect(screen.getByText('5000')).toBeInTheDocument();
+      expect(screen.getByText('10000')).toBeInTheDocument();
+    });
+
+    it("calls handleClick upon clicking '뒤로가기'", () => {
+      renderResult();
+
+      fireEvent.click(screen.getByRole('link', {
+        name: '뒤로가기',
+      }));
+
+      expect(goBack).toBeCalledWith({ url: '/apartment' });
+    });
+  });
+
+  context('without profile', () => {
+    given('profile', () => initialUserField);
+
+    it('renders a link for user to enter their profile', () => {
+      renderResult();
+      expect(screen.getByText('정보를 아직 입력하지 않으셨습니다.')).toBeInTheDocument();
+
+      expect(screen.getByRole('link', {
+        name: '내 정보 입력 하러가기',
+      })).toBeInTheDocument();
+    });
+
+    it("calls handleClick upon Clicking '입력' button.", () => {
+      renderResult();
+
+      fireEvent.click(screen.getByRole('link', {
+        name: '내 정보 입력 하러가기',
+      }));
+
+      expect(handleClick).toBeCalledWith({ url: '/profile/new' });
+    });
+  });
+});

--- a/src/pages/Result/ResultContainer.jsx
+++ b/src/pages/Result/ResultContainer.jsx
@@ -4,16 +4,19 @@ import { useSelector } from 'react-redux';
 
 import { get } from '../../utils/utils';
 
-import Profile from './Profile';
+import Result from './Result';
 
-export default function ProfileContainer({ onClickNewProfile }) {
+export default function ResultContainer({ onClick, goBack }) {
   const profile = useSelector(get('userFields'));
+  const apartment = useSelector(get('apartment'));
 
   return (
     <article>
-      <Profile
+      <Result
         profile={profile}
-        onClickNewProfile={onClickNewProfile}
+        apartment={apartment}
+        onClick={onClick}
+        goBack={goBack}
       />
     </article>
   );

--- a/src/pages/Result/ResultContainer.test.jsx
+++ b/src/pages/Result/ResultContainer.test.jsx
@@ -1,0 +1,67 @@
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+import { useSelector } from 'react-redux';
+
+import given from 'given2';
+
+import { initialUserField } from '../../fixtures/initials';
+
+import ResultContainer from './ResultContainer';
+
+describe('ResultContainer', () => {
+  const profile = {
+    isNew: false,
+    name: '신형탁',
+    age: 29,
+    salary: 5000,
+    asset: 10000,
+  };
+
+  const apartment = {
+    name: '아크로리버파크',
+    date: '2021-03',
+    district: '반포동',
+    area: '129.92',
+    price: '470,000',
+    lotNumber: 1,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    useSelector.mockImplementation((selector) => selector({
+      userFields: given.profile,
+      apartment,
+    }));
+  });
+
+  context('with profile', () => {
+    given('profile', () => profile);
+
+    it('renders result page', () => {
+      render(<ResultContainer />);
+
+      expect(screen.getByText('아크로리버파크')).toBeInTheDocument();
+      expect(screen.getByText('129.92')).toBeInTheDocument();
+      expect(screen.getByText('470,000')).toBeInTheDocument();
+      expect(screen.getByText('2021-03')).toBeInTheDocument();
+      expect(screen.getByText('반포동')).toBeInTheDocument();
+      expect(screen.getByText('1')).toBeInTheDocument();
+    });
+  });
+
+  context('without profile', () => {
+    given('profile', () => initialUserField);
+    it('renders link for user to fill up the profile', () => {
+      render(<ResultContainer />);
+
+      expect(screen.getByText('정보를 아직 입력하지 않으셨습니다.')).toBeInTheDocument();
+
+      expect(screen.getByRole('link', {
+        name: '내 정보 입력 하러가기',
+      })).toBeInTheDocument();
+    });
+  });
+});

--- a/src/pages/Result/ResultPage.jsx
+++ b/src/pages/Result/ResultPage.jsx
@@ -1,0 +1,29 @@
+import React, { useCallback } from 'react';
+
+import { useHistory } from 'react-router-dom';
+
+import ResultContainer from './ResultContainer';
+
+export default function ResultPage() {
+  const history = useHistory();
+
+  const goBack = useCallback(() => {
+    history.goBack();
+  }, [history]);
+
+  const handleClick = useCallback(({ url }) => {
+    history.push(url);
+  }, [history]);
+
+  return (
+    <section>
+      <header>
+        결과
+      </header>
+      <ResultContainer
+        onClick={handleClick}
+        goBack={goBack}
+      />
+    </section>
+  );
+}

--- a/src/pages/Result/ResultPage.test.jsx
+++ b/src/pages/Result/ResultPage.test.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { useSelector } from 'react-redux';
+
+import { render, screen } from '@testing-library/react';
+
+import ResultPage from './ResultPage';
+
+describe('ResultPage', () => {
+  const profile = {
+    isNew: false,
+    name: '신형탁',
+    age: 29,
+    salary: 5000,
+    asset: 10000,
+  };
+
+  const apartment = {
+    name: '아크로리버파크',
+    date: '2021-03',
+    district: '반포동',
+    area: '129.92',
+    price: '470,000',
+    lotNumber: 1,
+  };
+
+  beforeEach(() => {
+    useSelector.mockImplementation((selector) => selector({
+      apartment,
+      userFields: profile,
+    }));
+  });
+
+  it('renders result page', () => {
+    render((
+      <MemoryRouter>
+        <ResultPage />
+      </MemoryRouter>
+    ));
+
+    expect(screen.getByText('결과')).toBeInTheDocument();
+  });
+});

--- a/src/pages/Result/index.js
+++ b/src/pages/Result/index.js
@@ -1,0 +1,1 @@
+export { default } from './ResultPage';

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -2,4 +2,5 @@ export { default as HomePage } from './Home';
 export { default as ProfilePage } from './Profile';
 export { default as NewProfilePage } from './NewProfile';
 export { default as ApartmentPage } from './Apartment';
+export { default as ResultPage } from './Result';
 export { default as NotFoundPage } from './NotFound';

--- a/src/redux/appSlice.js
+++ b/src/redux/appSlice.js
@@ -39,25 +39,37 @@ const { actions, reducer } = createSlice({
       };
     },
 
-    setApartment(state, { payload: apartments }) {
+    setApartments(state, { payload: apartments }) {
       return {
         ...state,
         apartments,
       };
     },
 
+    setApartment(state, { payload: apartment }) {
+      return {
+        ...state,
+        apartment,
+      };
+    },
+
   },
 });
 
-export const { setUserFields, changeUserFields, setApartment } = actions;
+export const {
+  setUserFields,
+  changeUserFields,
+  setApartments,
+  setApartment,
+} = actions;
 
 export function loadApartments(apartmentCategory) {
   return async (dispatch) => {
-    dispatch(setApartment([]));
+    dispatch(setApartments([]));
 
     const apartments = await fetchApartments({ apartmentCategory });
 
-    dispatch(setApartment(apartments));
+    dispatch(setApartments(apartments));
   };
 }
 

--- a/src/redux/appSlice.test.js
+++ b/src/redux/appSlice.test.js
@@ -5,6 +5,7 @@ import configureStore from 'redux-mock-store';
 import reducer, {
   setUserFields,
   changeUserFields,
+  setApartments,
   setApartment,
   loadApartments,
 } from './appSlice';
@@ -115,13 +116,33 @@ describe('setApartments', () => {
       },
     ];
 
-    const state = reducer(initialState, setApartment(APARTMENTS));
+    const state = reducer(initialState, setApartments(APARTMENTS));
 
     expect(state.apartments[0].name).toBe('아크로리버파크');
     expect(state.apartments[0].price).toBe('470,000');
     expect(state.apartments[0].area).toBe('129.92');
 
     expect(state.apartments).toHaveLength(2);
+  });
+});
+
+describe('setApartment', () => {
+  it('changes apartment', () => {
+    const initialState = {
+      apartment: {},
+    };
+
+    const apartment = {
+      name: '아크로리버파크',
+      date: '2021-03',
+      area: '129.92',
+      price: '470,000',
+      lotNumber: 1,
+    };
+
+    const state = reducer(initialState, setApartment(apartment));
+
+    expect(state.apartment).toEqual(apartment);
   });
 });
 
@@ -133,8 +154,8 @@ describe('loadApartments', () => {
 
     const actions = store.getActions();
 
-    expect(actions[0]).toEqual(setApartment([]));
-    expect(actions[1]).toEqual(setApartment([
+    expect(actions[0]).toEqual(setApartments([]));
+    expect(actions[1]).toEqual(setApartments([
       {
         name: '아크로리버파크',
         date: '2021-03',


### PR DESCRIPTION
Users can now check out the details of the apartment which they select on the apartment page.

If Users haven't filled up the form yet, the result screen shows a link to enter their information.

![apartment details](https://user-images.githubusercontent.com/77006427/113677437-8b6a7e00-96f8-11eb-8690-1213ad6648a5.gif)
