### PR TITLE
🐛 fix: provide apartment data upon refresh on result page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,7 +5,7 @@ import { useDispatch } from 'react-redux';
 
 import { loadItem } from './services/storage';
 
-import { setUserFields } from './redux/appSlice';
+import { setApartment, setUserFields } from './redux/appSlice';
 
 import {
   HomePage,
@@ -20,9 +20,14 @@ export default function App() {
   const dispatch = useDispatch();
 
   const profile = JSON.parse((loadItem('profile')));
+  const apartment = JSON.parse((loadItem('apartment')));
 
   if (profile) {
     dispatch(setUserFields(profile));
+  }
+
+  if (apartment) {
+    dispatch(setApartment(apartment));
   }
 
   return (

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -88,6 +88,7 @@ describe('App', () => {
   context('with path /', () => {
     beforeEach(() => {
       loadItem.mockImplementation(() => (JSON.stringify(profile)));
+      loadItem.mockImplementation(() => (JSON.stringify(apartment)));
     });
 
     it('renders the home page', () => {

--- a/src/fixtures/initials/index.js
+++ b/src/fixtures/initials/index.js
@@ -1,1 +1,5 @@
-export { initialUserField, dummy } from './initials';
+export {
+  initialUserField,
+  initialApartment,
+  initialEstimation,
+} from './initials';

--- a/src/fixtures/initials/initials.js
+++ b/src/fixtures/initials/initials.js
@@ -6,7 +6,23 @@ const initialUserField = {
   asset: 0,
 };
 
-export { initialUserField };
+const initialApartment = {
+  name: '',
+  price: 0,
+  date: '',
+  district: '',
+  area: 0,
+  lotNumber: '',
+};
 
-// TODO: TO BE DELETED SOON
-export const dummy = {};
+const initialEstimation = {
+  price: 0,
+  year: 0,
+  age: 0,
+};
+
+export {
+  initialUserField,
+  initialApartment,
+  initialEstimation,
+};

--- a/src/redux/appSlice.js
+++ b/src/redux/appSlice.js
@@ -1,6 +1,10 @@
 import { createSlice } from '@reduxjs/toolkit';
 
-import { initialUserField } from '../fixtures/initials';
+import {
+  initialUserField,
+  initialApartment,
+  initialEstimation,
+} from '../fixtures/initials';
 
 import { fetchApartments } from '../services/api';
 
@@ -13,10 +17,11 @@ const { actions, reducer } = createSlice({
       ...initialUserField,
     },
     apartments: [],
+    apartment: {
+      ...initialApartment,
+    },
     estimation: {
-      price: 0,
-      year: 0,
-      age: 0,
+      ...initialEstimation,
     },
   },
   reducers: {
@@ -52,6 +57,8 @@ const { actions, reducer } = createSlice({
     },
 
     setApartment(state, { payload: apartment }) {
+      saveItem('apartment', JSON.stringify(apartment));
+
       return {
         ...state,
         apartment,


### PR DESCRIPTION
Save and load apartment data when users select apartment via localStorage.

![image](https://user-images.githubusercontent.com/77006427/113800013-29118c00-9791-11eb-9303-f7feed831dcd.png)
