### PR TITLE
🐛fix: redundant path upon clicking home

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -12,7 +12,7 @@ import App from './App';
 ReactDOM.render(
   (
     <Provider store={store}>
-      <BrowserRouter basename="howmuchmore.xyz/">
+      <BrowserRouter>
         <App />
       </BrowserRouter>
     </Provider>


### PR DESCRIPTION
Removed basename since 404.html does set the base route on gh-page. #57 

The arising issue is clicking the link refreshes the website when users access the index(homepage) at first. 
Afterward, it does not refresh on any link events.

This issue isn't a new issue due to the removal of the basename.
Even with basename, the issue mentioned above occurs.