### PR TITLE
💥 breaking change: replace 'area' with 'size' for apartment data

### DIFF
--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -29,14 +29,14 @@ describe('App', () => {
     {
       name: '아크로리버파크',
       date: '2021-03',
-      area: '129.92',
+      size: '129.92',
       price: '470,000',
       lotNumber: 1,
     },
     {
       name: '서울',
       date: '2021-02',
-      area: '200.27',
+      size: '200.27',
       price: '420,000',
       lotNumber: 2,
     },
@@ -46,7 +46,7 @@ describe('App', () => {
     name: '아크로리버파크',
     date: '2021-03',
     district: '반포동',
-    area: '129.92',
+    size: '129.92',
     price: '470,000',
     lotNumber: 1,
   };

--- a/src/components/LinkField.test.jsx
+++ b/src/components/LinkField.test.jsx
@@ -55,7 +55,7 @@ describe('LinkField', () => {
         apartment={{
           name: '아크로리버파크',
           date: '2021-03',
-          area: '129.92',
+          size: '129.92',
           price: '470,000',
           lotNumber: 1,
         }}

--- a/src/fixtures/initials/initials.js
+++ b/src/fixtures/initials/initials.js
@@ -11,7 +11,7 @@ const initialApartment = {
   price: '',
   date: '',
   district: '',
-  area: '',
+  size: '',
   lotNumber: '',
 };
 

--- a/src/pages/Apartment/Apartment.jsx
+++ b/src/pages/Apartment/Apartment.jsx
@@ -4,7 +4,7 @@ export default function Apartment({ apartment }) {
   const {
     name,
     district,
-    area,
+    size,
   } = apartment;
 
   return (
@@ -14,7 +14,7 @@ export default function Apartment({ apartment }) {
       <dd>법정동:</dd>
       <dt>{district}</dt>
       <dd>전용면적:</dd>
-      <dt>{area}</dt>
+      <dt>{size}</dt>
     </dl>
   );
 }

--- a/src/pages/Apartment/Apartment.test.jsx
+++ b/src/pages/Apartment/Apartment.test.jsx
@@ -9,7 +9,7 @@ describe('Apartment', () => {
     name: '아크로리버파크',
     date: '2021-03',
     district: '반포동',
-    area: '129.92',
+    size: '129.92',
     price: '470,000',
     lotNumber: 1,
   };

--- a/src/pages/Apartment/ApartmentPage.test.jsx
+++ b/src/pages/Apartment/ApartmentPage.test.jsx
@@ -17,14 +17,14 @@ describe('ApartmentPage', () => {
         {
           name: '아크로리버파크',
           date: '2021-03',
-          area: '129.92',
+          size: '129.92',
           price: '470,000',
           lotNumber: 1,
         },
         {
           name: '서울',
           date: '2021-02',
-          area: '200.27',
+          size: '200.27',
           price: '420,000',
           lotNumber: 2,
         },

--- a/src/pages/Apartment/Apartments.test.jsx
+++ b/src/pages/Apartment/Apartments.test.jsx
@@ -12,14 +12,14 @@ describe('Apartments', () => {
     {
       name: '아크로리버파크',
       date: '2021-03',
-      area: '129.92',
+      size: '129.92',
       price: '470,000',
       lotNumber: 1,
     },
     {
       name: '서울',
       date: '2021-02',
-      area: '200.27',
+      size: '200.27',
       price: '420,000',
       lotNumber: 2,
     },

--- a/src/pages/Apartment/ApartmentsContainer.test.jsx
+++ b/src/pages/Apartment/ApartmentsContainer.test.jsx
@@ -19,14 +19,14 @@ describe('ApartmentsContainer', () => {
         {
           name: '아크로리버파크',
           date: '2021-03',
-          area: '129.92',
+          size: '129.92',
           price: '470,000',
           lotNumber: 1,
         },
         {
           name: '서울',
           date: '2021-02',
-          area: '200.27',
+          size: '200.27',
           price: '420,000',
           lotNumber: 2,
         },

--- a/src/pages/Result/ApartmentDetail.jsx
+++ b/src/pages/Result/ApartmentDetail.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 export default function ApartmentDetail({ apartment }) {
   const {
     name,
-    area,
+    size,
     price,
     date,
     district,
@@ -24,7 +24,7 @@ export default function ApartmentDetail({ apartment }) {
           전용면적:
         </dd>
         <dt>
-          {area}
+          {size}
         </dt>
 
         <dd>

--- a/src/pages/Result/ApartmentDetail.test.jsx
+++ b/src/pages/Result/ApartmentDetail.test.jsx
@@ -9,7 +9,7 @@ describe('ApartmentDetail', () => {
     name: '아크로리버파크',
     date: '2021-03',
     district: '반포동',
-    area: '129.92',
+    size: '129.92',
     price: '470,000',
     lotNumber: 1,
   };

--- a/src/pages/Result/Result.test.jsx
+++ b/src/pages/Result/Result.test.jsx
@@ -28,7 +28,7 @@ describe('Result', () => {
     name: '아크로리버파크',
     date: '2021-03',
     district: '반포동',
-    area: '129.92',
+    size: '129.92',
     price: '470,000',
     lotNumber: 1,
   };

--- a/src/pages/Result/ResultContainer.test.jsx
+++ b/src/pages/Result/ResultContainer.test.jsx
@@ -25,7 +25,7 @@ describe('ResultContainer', () => {
     name: '아크로리버파크',
     date: '2021-03',
     district: '반포동',
-    area: '129.92',
+    size: '129.92',
     price: '470,000',
     lotNumber: 1,
   };

--- a/src/pages/Result/ResultPage.test.jsx
+++ b/src/pages/Result/ResultPage.test.jsx
@@ -22,7 +22,7 @@ describe('ResultPage', () => {
     name: '아크로리버파크',
     date: '2021-03',
     district: '반포동',
-    area: '129.92',
+    size: '129.92',
     price: '470,000',
     lotNumber: 1,
   };

--- a/src/redux/appSlice.test.js
+++ b/src/redux/appSlice.test.js
@@ -113,14 +113,14 @@ describe('setApartments', () => {
         id: 1,
         name: '아크로리버파크',
         date: '2021-03',
-        area: '129.92',
+        size: '129.92',
         price: '470,000',
       },
       {
         id: 2,
         name: '서울',
         date: '2021-02',
-        area: '200.27',
+        size: '200.27',
         price: '420,000',
       },
     ];
@@ -129,7 +129,7 @@ describe('setApartments', () => {
 
     expect(state.apartments[0].name).toBe('아크로리버파크');
     expect(state.apartments[0].price).toBe('470,000');
-    expect(state.apartments[0].area).toBe('129.92');
+    expect(state.apartments[0].size).toBe('129.92');
 
     expect(state.apartments).toHaveLength(2);
   });
@@ -144,7 +144,7 @@ describe('setApartment', () => {
     const apartment = {
       name: '아크로리버파크',
       date: '2021-03',
-      area: '129.92',
+      size: '129.92',
       price: '470,000',
       lotNumber: 1,
     };
@@ -190,14 +190,14 @@ describe('loadApartments', () => {
       {
         name: '아크로리버파크',
         date: '2021-03',
-        area: '129.92',
+        size: '129.92',
         price: '470,000',
         lotNumber: 1,
       },
       {
         name: '서울',
         date: '2021-02',
-        area: '200.27',
+        size: '200.27',
         price: '420,000',
         lotNumber: 2,
       },

--- a/src/services/__mocks__/api.js
+++ b/src/services/__mocks__/api.js
@@ -3,14 +3,14 @@ export async function fetchApartments() {
     {
       name: '아크로리버파크',
       date: '2021-03',
-      area: '129.92',
+      size: '129.92',
       price: '470,000',
       lotNumber: 1,
     },
     {
       name: '서울',
       date: '2021-02',
-      area: '200.27',
+      size: '200.27',
       price: '420,000',
       lotNumber: 2,
     },

--- a/src/services/api.test.js
+++ b/src/services/api.test.js
@@ -7,14 +7,14 @@ describe('api', () => {
     {
       name: '아크로리버파크',
       date: '2021-03',
-      area: '129.92',
+      size: '129.92',
       price: '470,000',
       lotNumber: 1,
     },
     {
       name: '서울',
       date: '2021-02',
-      area: '200.27',
+      size: '200.27',
       price: '420,000',
       lotNumber: 2,
     },


### PR DESCRIPTION
Due to changes in processing apartment data from the server,
client-side also replace the name 'area' with 'size.'

Both definitions of the word 'size' and 'area' are somewhat identical.
Not to be confused with a certain area of location, I chose size instead of area.

![image](https://user-images.githubusercontent.com/77006427/114140198-eeebea00-994a-11eb-8f7f-b7922ecbf68e.png)
