### PR TITLE
🐛fix: Replace profile object keys at localStorage with 'monthlySaving…

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,8 @@ import { useDispatch } from 'react-redux';
 
 import { loadItem } from './services/storage';
 
+import { processObject } from './utils/utils';
+
 import { setApartment, setUserFields } from './redux/appSlice';
 
 import {
@@ -21,6 +23,14 @@ export default function App() {
 
   const profile = JSON.parse((loadItem('profile')));
   const apartment = JSON.parse((loadItem('apartment')));
+
+  if (profile && profile.salary) {
+    dispatch(setUserFields(processObject({
+      object: profile,
+      legacyKeys: ['salary', 'asset'],
+      newKeys: ['monthlySavings', 'currentBalance'],
+    })));
+  }
 
   if (profile) {
     dispatch(setUserFields(profile));

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -17,6 +17,14 @@ jest.mock('./services/storage');
 describe('App', () => {
   const dispatch = jest.fn();
 
+  const legacyprofile = {
+    isNew: false,
+    name: '신형탁',
+    age: '29',
+    salary: 5000,
+    asset: 10000,
+  };
+
   const profile = {
     isNew: false,
     name: '신형탁',
@@ -89,6 +97,18 @@ describe('App', () => {
     beforeEach(() => {
       loadItem.mockImplementation(() => (JSON.stringify(profile)));
       loadItem.mockImplementation(() => (JSON.stringify(apartment)));
+    });
+
+    context('with legacy profile', () => {
+      beforeEach(() => {
+        loadItem.mockImplementation(() => (JSON.stringify(legacyprofile)));
+      });
+
+      it('excutes dispatch', () => {
+        renderApp({ path: '/' });
+
+        expect(dispatch).toBeCalled();
+      });
     });
 
     it('renders the home page', () => {

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -14,3 +14,24 @@ export function isExist(object) {
 
   return (!nonExistingKey);
 }
+
+export function processObject({ object, legacyKeys, newKeys }) {
+  const temporary = { ...object };
+
+  legacyKeys.forEach((key) => {
+    delete temporary[key];
+  });
+
+  const newObject = newKeys.reduce((accumulator, current) => {
+    if (!accumulator[current]) {
+      return {
+        ...accumulator,
+        [current]: 0,
+      };
+    }
+
+    return accumulator;
+  }, { ...temporary });
+
+  return newObject;
+}

--- a/src/utils/utils.test.js
+++ b/src/utils/utils.test.js
@@ -1,4 +1,8 @@
-import { get, isExist } from './utils';
+import {
+  get,
+  isExist,
+  processObject,
+} from './utils';
 
 test('get', () => {
   const state = {
@@ -31,4 +35,26 @@ test('isExist', () => {
 
   expect(isExist(object)).toBeTruthy();
   expect(isExist(incompleteObject)).toBeFalsy();
+});
+
+test('processObject', () => {
+  const object = {
+    isNew: false,
+    name: '신형탁',
+    salary: '5000',
+    asset: '10000',
+  };
+
+  const legacyKeys = ['salary', 'asset'];
+
+  const newKeys = ['monthlySavings', 'currentBalance'];
+
+  const result = {
+    isNew: false,
+    name: '신형탁',
+    monthlySavings: 0,
+    currentBalance: 0,
+  };
+
+  expect(processObject({ object, legacyKeys, newKeys })).toEqual(result);
 });


### PR DESCRIPTION
…' and 'currentBalance'

The users who filled up their salary and asset on the form in the previous version could not access the entire page.
Issue #62 
PR: updating Keys #61 

![image](https://user-images.githubusercontent.com/77006427/114272591-bedb3e80-9a51-11eb-832e-cf4fe055503c.png)
