### PR TITLE
✨ feat: Use KR currency '₩' as a prefix for price number

### DIFF
--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -138,8 +138,8 @@ describe('App', () => {
 
       expect(screen.getByText('신형탁')).toBeInTheDocument();
       expect(screen.getByText('29')).toBeInTheDocument();
-      expect(screen.getByText('5,000')).toBeInTheDocument();
-      expect(screen.getByText('10,000')).toBeInTheDocument();
+      expect(screen.getByText('₩5,000')).toBeInTheDocument();
+      expect(screen.getByText('₩10,000')).toBeInTheDocument();
     });
   });
 
@@ -167,7 +167,7 @@ describe('App', () => {
 
       expect(screen.getByText('아크로리버파크')).toBeInTheDocument();
       expect(screen.getByText('129.92')).toBeInTheDocument();
-      expect(screen.getByText('470,000')).toBeInTheDocument();
+      expect(screen.getByText('₩470,000')).toBeInTheDocument();
     });
   });
 

--- a/src/pages/Profile/Profile.test.jsx
+++ b/src/pages/Profile/Profile.test.jsx
@@ -34,8 +34,8 @@ describe('Profile', () => {
 
       expect(screen.getByText('신형탁')).toBeInTheDocument();
       expect(screen.getByText('29')).toBeInTheDocument();
-      expect(screen.getByText('5,000')).toBeInTheDocument();
-      expect(screen.getByText('10,000')).toBeInTheDocument();
+      expect(screen.getByText('₩5,000')).toBeInTheDocument();
+      expect(screen.getByText('₩10,000')).toBeInTheDocument();
     });
 
     it('calls handleClick upon clicking edit', () => {

--- a/src/pages/Profile/ProfileContainer.test.jsx
+++ b/src/pages/Profile/ProfileContainer.test.jsx
@@ -31,8 +31,8 @@ describe('ProfileContainer', () => {
 
       expect(screen.getByText('신형탁')).toBeInTheDocument();
       expect(screen.getByText('29')).toBeInTheDocument();
-      expect(screen.getByText('5,000')).toBeInTheDocument();
-      expect(screen.getByText('10,000')).toBeInTheDocument();
+      expect(screen.getByText('₩5,000')).toBeInTheDocument();
+      expect(screen.getByText('₩10,000')).toBeInTheDocument();
     });
   });
 

--- a/src/pages/Profile/ProfilePage.test.jsx
+++ b/src/pages/Profile/ProfilePage.test.jsx
@@ -29,7 +29,7 @@ describe('ProfilePage', () => {
 
     expect(screen.getByText('신형탁')).toBeInTheDocument();
     expect(screen.getByText('29')).toBeInTheDocument();
-    expect(screen.getByText('5,000')).toBeInTheDocument();
-    expect(screen.getByText('10,000')).toBeInTheDocument();
+    expect(screen.getByText('₩5,000')).toBeInTheDocument();
+    expect(screen.getByText('₩10,000')).toBeInTheDocument();
   });
 });

--- a/src/pages/Profile/User.jsx
+++ b/src/pages/Profile/User.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { convertToKRW } from '../../utils/utils';
 
 export default function User({ profile }) {
   const {
@@ -12,9 +13,13 @@ export default function User({ profile }) {
       <dd>나이:</dd>
       <dt>{age}</dt>
       <dd>월 저축 금액(만원):</dd>
-      <dt>{monthlySavings.toLocaleString()}</dt>
+      <dt>
+        {convertToKRW(monthlySavings)}
+      </dt>
       <dd>현재 은행 잔액(만원):</dd>
-      <dt>{currentBalance.toLocaleString()}</dt>
+      <dt>
+        {convertToKRW(currentBalance)}
+      </dt>
     </dl>
   );
 }

--- a/src/pages/Profile/User.test.jsx
+++ b/src/pages/Profile/User.test.jsx
@@ -20,7 +20,7 @@ describe('User', () => {
 
     expect(screen.getByText('신형탁')).toBeInTheDocument();
     expect(screen.getByText('29')).toBeInTheDocument();
-    expect(screen.getByText('5,000')).toBeInTheDocument();
-    expect(screen.getByText('10,000')).toBeInTheDocument();
+    expect(screen.getByText('₩5,000')).toBeInTheDocument();
+    expect(screen.getByText('₩10,000')).toBeInTheDocument();
   });
 });

--- a/src/pages/Result/ApartmentDetail.jsx
+++ b/src/pages/Result/ApartmentDetail.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { convertToKRW } from '../../utils/utils';
 
 export default function ApartmentDetail({ apartment }) {
   const {
@@ -13,44 +14,32 @@ export default function ApartmentDetail({ apartment }) {
   return (
     <>
       <dl>
-        <dd>
-          아파트명:
-        </dd>
+        <dd>아파트명:</dd>
         <dt>
           {name}
         </dt>
 
-        <dd>
-          전용면적:
-        </dd>
+        <dd>전용면적:</dd>
         <dt>
           {size}
         </dt>
 
-        <dd>
-          거래금액:
-        </dd>
+        <dd>거래금액:</dd>
         <dt>
-          {price.toLocaleString()}
+          {convertToKRW(price)}
         </dt>
 
-        <dd>
-          매매일자:
-        </dd>
+        <dd>매매일자:</dd>
         <dt>
           {date}
         </dt>
 
-        <dd>
-          법정동:
-        </dd>
+        <dd>법정동:</dd>
         <dt>
           {district}
         </dt>
 
-        <dd>
-          지번:
-        </dd>
+        <dd>지번:</dd>
         <dt>
           {lotNumber}
         </dt>

--- a/src/pages/Result/ApartmentDetail.test.jsx
+++ b/src/pages/Result/ApartmentDetail.test.jsx
@@ -19,7 +19,7 @@ describe('ApartmentDetail', () => {
 
     expect(screen.getByText('아크로리버파크')).toBeInTheDocument();
     expect(screen.getByText('129.92')).toBeInTheDocument();
-    expect(screen.getByText('470,000')).toBeInTheDocument();
+    expect(screen.getByText('₩470,000')).toBeInTheDocument();
     expect(screen.getByText('2021-03')).toBeInTheDocument();
     expect(screen.getByText('반포동')).toBeInTheDocument();
     expect(screen.getByText('1')).toBeInTheDocument();

--- a/src/pages/Result/Estimation.jsx
+++ b/src/pages/Result/Estimation.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { convertToKRW } from '../../utils/utils';
 
 export default function Estimation({ estimation }) {
   const { price, year, age } = estimation;
@@ -6,11 +7,17 @@ export default function Estimation({ estimation }) {
   return (
     <dl>
       <dd>필요 금액(만원):</dd>
-      <dt>{price.toLocaleString()}</dt>
+      <dt>
+        {convertToKRW(price)}
+      </dt>
       <dd>소요 기간(년):</dd>
-      <dt>{year.toLocaleString()}</dt>
+      <dt>
+        {year.toLocaleString()}
+      </dt>
       <dd>구매 할 때 나이: </dd>
-      <dt>{age.toLocaleString()}</dt>
+      <dt>
+        {age.toLocaleString()}
+      </dt>
     </dl>
   );
 }

--- a/src/pages/Result/Estimation.test.jsx
+++ b/src/pages/Result/Estimation.test.jsx
@@ -6,7 +6,7 @@ import Estimation from './Estimation';
 
 describe('Estimation', () => {
   const estimation = {
-    price: '460000',
+    price: 460000,
     year: '94',
     age: '123',
   };
@@ -14,7 +14,7 @@ describe('Estimation', () => {
   it('renders Estimation', () => {
     render(<Estimation estimation={estimation} />);
 
-    expect(screen.getByText('460000')).toBeInTheDocument();
+    expect(screen.getByText('₩460,000')).toBeInTheDocument();
     expect(screen.getByText('94')).toBeInTheDocument();
     expect(screen.getByText('123')).toBeInTheDocument();
   });

--- a/src/pages/Result/Result.test.jsx
+++ b/src/pages/Result/Result.test.jsx
@@ -63,7 +63,7 @@ describe('Result', () => {
 
       expect(screen.getByText('아크로리버파크')).toBeInTheDocument();
       expect(screen.getByText('129.92')).toBeInTheDocument();
-      expect(screen.getByText('470,000')).toBeInTheDocument();
+      expect(screen.getByText('₩470,000')).toBeInTheDocument();
       expect(screen.getByText('2021-03')).toBeInTheDocument();
       expect(screen.getByText('반포동')).toBeInTheDocument();
       expect(screen.getByText('1')).toBeInTheDocument();
@@ -74,8 +74,8 @@ describe('Result', () => {
 
       expect(screen.getByText('신형탁')).toBeInTheDocument();
       expect(screen.getByText('29')).toBeInTheDocument();
-      expect(screen.getByText('5,000')).toBeInTheDocument();
-      expect(screen.getByText('10,000')).toBeInTheDocument();
+      expect(screen.getByText('₩5,000')).toBeInTheDocument();
+      expect(screen.getByText('₩10,000')).toBeInTheDocument();
     });
 
     it('renders Esitmation', () => {

--- a/src/pages/Result/ResultContainer.test.jsx
+++ b/src/pages/Result/ResultContainer.test.jsx
@@ -57,7 +57,7 @@ describe('ResultContainer', () => {
 
       expect(screen.getByText('아크로리버파크')).toBeInTheDocument();
       expect(screen.getByText('129.92')).toBeInTheDocument();
-      expect(screen.getByText('470,000')).toBeInTheDocument();
+      expect(screen.getByText('₩470,000')).toBeInTheDocument();
       expect(screen.getByText('2021-03')).toBeInTheDocument();
       expect(screen.getByText('반포동')).toBeInTheDocument();
       expect(screen.getByText('1')).toBeInTheDocument();

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -35,3 +35,9 @@ export function filterObject({ object, legacyKeys, newKeys }) {
 
   return newObject;
 }
+
+export function convertToKRW(price) {
+  return price.toLocaleString('ko-KR', {
+    style: 'currency', currency: 'KRW',
+  });
+}

--- a/src/utils/utils.test.js
+++ b/src/utils/utils.test.js
@@ -2,6 +2,7 @@ import {
   get,
   isExist,
   filterObject,
+  convertToKRW,
 } from './utils';
 
 test('get', () => {
@@ -59,4 +60,10 @@ test('filterObject', () => {
   };
 
   expect(filterObject({ object, legacyKeys, newKeys })).toEqual(result);
+});
+
+test('convertToKRW', () => {
+  const price = 5000;
+
+  expect(convertToKRW(price)).toBe('₩5,000');
 });


### PR DESCRIPTION
The current target users of the service at now are Korean.

Showing their currency number helps their readability and distinguishes price
from other numbers such as age, name, lot number, etc.

![image](https://user-images.githubusercontent.com/77006427/114349977-88add400-9ba3-11eb-8652-3f497d71fd25.png)


![image](https://user-images.githubusercontent.com/77006427/114349858-63b96100-9ba3-11eb-8d5b-7402a317810b.png)
