### PR TITLE
♻️ refactor: Use '원' Instead of KR Currency Symbol '₩'

### DIFF
--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -138,8 +138,8 @@ describe('App', () => {
 
       expect(screen.getByText('신형탁')).toBeInTheDocument();
       expect(screen.getByText('29')).toBeInTheDocument();
-      expect(screen.getByText('₩5,000')).toBeInTheDocument();
-      expect(screen.getByText('₩10,000')).toBeInTheDocument();
+      expect(screen.getByText('5,000 원')).toBeInTheDocument();
+      expect(screen.getByText('10,000 원')).toBeInTheDocument();
     });
   });
 
@@ -167,7 +167,7 @@ describe('App', () => {
 
       expect(screen.getByText('아크로리버파크')).toBeInTheDocument();
       expect(screen.getByText('129.92')).toBeInTheDocument();
-      expect(screen.getByText('₩470,000')).toBeInTheDocument();
+      expect(screen.getByText('470,000 원')).toBeInTheDocument();
     });
   });
 

--- a/src/pages/Profile/Profile.test.jsx
+++ b/src/pages/Profile/Profile.test.jsx
@@ -34,8 +34,8 @@ describe('Profile', () => {
 
       expect(screen.getByText('신형탁')).toBeInTheDocument();
       expect(screen.getByText('29')).toBeInTheDocument();
-      expect(screen.getByText('₩5,000')).toBeInTheDocument();
-      expect(screen.getByText('₩10,000')).toBeInTheDocument();
+      expect(screen.getByText('5,000 원')).toBeInTheDocument();
+      expect(screen.getByText('10,000 원')).toBeInTheDocument();
     });
 
     it('calls handleClick upon clicking edit', () => {

--- a/src/pages/Profile/ProfileContainer.test.jsx
+++ b/src/pages/Profile/ProfileContainer.test.jsx
@@ -31,8 +31,8 @@ describe('ProfileContainer', () => {
 
       expect(screen.getByText('신형탁')).toBeInTheDocument();
       expect(screen.getByText('29')).toBeInTheDocument();
-      expect(screen.getByText('₩5,000')).toBeInTheDocument();
-      expect(screen.getByText('₩10,000')).toBeInTheDocument();
+      expect(screen.getByText('5,000 원')).toBeInTheDocument();
+      expect(screen.getByText('10,000 원')).toBeInTheDocument();
     });
   });
 

--- a/src/pages/Profile/ProfilePage.test.jsx
+++ b/src/pages/Profile/ProfilePage.test.jsx
@@ -29,7 +29,7 @@ describe('ProfilePage', () => {
 
     expect(screen.getByText('신형탁')).toBeInTheDocument();
     expect(screen.getByText('29')).toBeInTheDocument();
-    expect(screen.getByText('₩5,000')).toBeInTheDocument();
-    expect(screen.getByText('₩10,000')).toBeInTheDocument();
+    expect(screen.getByText('5,000 원')).toBeInTheDocument();
+    expect(screen.getByText('10,000 원')).toBeInTheDocument();
   });
 });

--- a/src/pages/Profile/User.jsx
+++ b/src/pages/Profile/User.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { convertToKRW } from '../../utils/utils';
 
 export default function User({ profile }) {
   const {
@@ -14,11 +13,11 @@ export default function User({ profile }) {
       <dt>{age}</dt>
       <dd>월 저축 금액(만원):</dd>
       <dt>
-        {convertToKRW(monthlySavings)}
+        {`${monthlySavings.toLocaleString()} 원`}
       </dt>
       <dd>현재 은행 잔액(만원):</dd>
       <dt>
-        {convertToKRW(currentBalance)}
+        {`${currentBalance.toLocaleString()} 원`}
       </dt>
     </dl>
   );

--- a/src/pages/Profile/User.test.jsx
+++ b/src/pages/Profile/User.test.jsx
@@ -20,7 +20,7 @@ describe('User', () => {
 
     expect(screen.getByText('신형탁')).toBeInTheDocument();
     expect(screen.getByText('29')).toBeInTheDocument();
-    expect(screen.getByText('₩5,000')).toBeInTheDocument();
-    expect(screen.getByText('₩10,000')).toBeInTheDocument();
+    expect(screen.getByText('5,000 원')).toBeInTheDocument();
+    expect(screen.getByText('10,000 원')).toBeInTheDocument();
   });
 });

--- a/src/pages/Result/ApartmentDetail.jsx
+++ b/src/pages/Result/ApartmentDetail.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { convertToKRW } from '../../utils/utils';
 
 export default function ApartmentDetail({ apartment }) {
   const {
@@ -26,7 +25,7 @@ export default function ApartmentDetail({ apartment }) {
 
         <dd>거래금액:</dd>
         <dt>
-          {convertToKRW(price)}
+          {`${price.toLocaleString()} 원`}
         </dt>
 
         <dd>매매일자:</dd>

--- a/src/pages/Result/ApartmentDetail.test.jsx
+++ b/src/pages/Result/ApartmentDetail.test.jsx
@@ -19,7 +19,7 @@ describe('ApartmentDetail', () => {
 
     expect(screen.getByText('아크로리버파크')).toBeInTheDocument();
     expect(screen.getByText('129.92')).toBeInTheDocument();
-    expect(screen.getByText('₩470,000')).toBeInTheDocument();
+    expect(screen.getByText('470,000 원')).toBeInTheDocument();
     expect(screen.getByText('2021-03')).toBeInTheDocument();
     expect(screen.getByText('반포동')).toBeInTheDocument();
     expect(screen.getByText('1')).toBeInTheDocument();

--- a/src/pages/Result/Estimation.jsx
+++ b/src/pages/Result/Estimation.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { convertToKRW } from '../../utils/utils';
 
 export default function Estimation({ estimation }) {
   const { price, year, age } = estimation;
@@ -8,7 +7,7 @@ export default function Estimation({ estimation }) {
     <dl>
       <dd>필요 금액(만원):</dd>
       <dt>
-        {convertToKRW(price)}
+        {`${price.toLocaleString()} 원`}
       </dt>
       <dd>소요 기간(년):</dd>
       <dt>

--- a/src/pages/Result/Estimation.test.jsx
+++ b/src/pages/Result/Estimation.test.jsx
@@ -14,7 +14,7 @@ describe('Estimation', () => {
   it('renders Estimation', () => {
     render(<Estimation estimation={estimation} />);
 
-    expect(screen.getByText('₩460,000')).toBeInTheDocument();
+    expect(screen.getByText('460,000 원')).toBeInTheDocument();
     expect(screen.getByText('94')).toBeInTheDocument();
     expect(screen.getByText('123')).toBeInTheDocument();
   });

--- a/src/pages/Result/Result.test.jsx
+++ b/src/pages/Result/Result.test.jsx
@@ -34,7 +34,7 @@ describe('Result', () => {
   };
 
   const estimation = {
-    price: '460000',
+    price: 460000,
     year: '94',
     age: '123',
   };
@@ -63,7 +63,7 @@ describe('Result', () => {
 
       expect(screen.getByText('아크로리버파크')).toBeInTheDocument();
       expect(screen.getByText('129.92')).toBeInTheDocument();
-      expect(screen.getByText('₩470,000')).toBeInTheDocument();
+      expect(screen.getByText('470,000 원')).toBeInTheDocument();
       expect(screen.getByText('2021-03')).toBeInTheDocument();
       expect(screen.getByText('반포동')).toBeInTheDocument();
       expect(screen.getByText('1')).toBeInTheDocument();
@@ -74,14 +74,14 @@ describe('Result', () => {
 
       expect(screen.getByText('신형탁')).toBeInTheDocument();
       expect(screen.getByText('29')).toBeInTheDocument();
-      expect(screen.getByText('₩5,000')).toBeInTheDocument();
-      expect(screen.getByText('₩10,000')).toBeInTheDocument();
+      expect(screen.getByText('5,000 원')).toBeInTheDocument();
+      expect(screen.getByText('10,000 원')).toBeInTheDocument();
     });
 
     it('renders Esitmation', () => {
       renderResult();
 
-      expect(screen.getByText('460000')).toBeInTheDocument();
+      expect(screen.getByText('460,000 원')).toBeInTheDocument();
       expect(screen.getByText('94')).toBeInTheDocument();
       expect(screen.getByText('123')).toBeInTheDocument();
     });

--- a/src/pages/Result/ResultContainer.test.jsx
+++ b/src/pages/Result/ResultContainer.test.jsx
@@ -57,7 +57,7 @@ describe('ResultContainer', () => {
 
       expect(screen.getByText('아크로리버파크')).toBeInTheDocument();
       expect(screen.getByText('129.92')).toBeInTheDocument();
-      expect(screen.getByText('₩470,000')).toBeInTheDocument();
+      expect(screen.getByText('470,000 원')).toBeInTheDocument();
       expect(screen.getByText('2021-03')).toBeInTheDocument();
       expect(screen.getByText('반포동')).toBeInTheDocument();
       expect(screen.getByText('1')).toBeInTheDocument();


### PR DESCRIPTION
Denoting Korean currency signs does drag back the User's reading experience.
Korean letters are intuitive compared to all other letters existing on the earth.

Looking through most bank applications or services,
they chose '원' rather than the symbol '₩' to denote the currency.

![image](https://user-images.githubusercontent.com/77006427/114471655-f3a2ed80-9c2b-11eb-91c4-d6bfc7728d75.png)
