### PR TITLE
✅ test: remove dependency on unit of number

### DIFF
--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -137,9 +137,9 @@ describe('App', () => {
       renderApp({ path: '/profile' });
 
       expect(screen.getByText('신형탁')).toBeInTheDocument();
-      expect(screen.getByText('29')).toBeInTheDocument();
-      expect(screen.getByText('5,000 원')).toBeInTheDocument();
-      expect(screen.getByText('10,000 원')).toBeInTheDocument();
+      expect(screen.getByText(/29/)).toBeInTheDocument();
+      expect(screen.getByText(/5,000/)).toBeInTheDocument();
+      expect(screen.getByText(/10,000/)).toBeInTheDocument();
     });
   });
 
@@ -167,7 +167,7 @@ describe('App', () => {
 
       expect(screen.getByText('아크로리버파크')).toBeInTheDocument();
       expect(screen.getByText('129.92')).toBeInTheDocument();
-      expect(screen.getByText('470,000 원')).toBeInTheDocument();
+      expect(screen.getByText(/470,000/)).toBeInTheDocument();
     });
   });
 

--- a/src/pages/Profile/Profile.test.jsx
+++ b/src/pages/Profile/Profile.test.jsx
@@ -33,9 +33,9 @@ describe('Profile', () => {
       renderProfile();
 
       expect(screen.getByText('신형탁')).toBeInTheDocument();
-      expect(screen.getByText('29')).toBeInTheDocument();
-      expect(screen.getByText('5,000 원')).toBeInTheDocument();
-      expect(screen.getByText('10,000 원')).toBeInTheDocument();
+      expect(screen.getByText(/29/)).toBeInTheDocument();
+      expect(screen.getByText(/5,000/)).toBeInTheDocument();
+      expect(screen.getByText(/10,000/)).toBeInTheDocument();
     });
 
     it('calls handleClick upon clicking edit', () => {

--- a/src/pages/Profile/ProfileContainer.test.jsx
+++ b/src/pages/Profile/ProfileContainer.test.jsx
@@ -30,9 +30,9 @@ describe('ProfileContainer', () => {
       render(<ProfileContainer />);
 
       expect(screen.getByText('신형탁')).toBeInTheDocument();
-      expect(screen.getByText('29')).toBeInTheDocument();
-      expect(screen.getByText('5,000 원')).toBeInTheDocument();
-      expect(screen.getByText('10,000 원')).toBeInTheDocument();
+      expect(screen.getByText(/29/)).toBeInTheDocument();
+      expect(screen.getByText(/5,000/)).toBeInTheDocument();
+      expect(screen.getByText(/10,000/)).toBeInTheDocument();
     });
   });
 

--- a/src/pages/Profile/ProfilePage.test.jsx
+++ b/src/pages/Profile/ProfilePage.test.jsx
@@ -28,8 +28,8 @@ describe('ProfilePage', () => {
     ));
 
     expect(screen.getByText('신형탁')).toBeInTheDocument();
-    expect(screen.getByText('29')).toBeInTheDocument();
-    expect(screen.getByText('5,000 원')).toBeInTheDocument();
-    expect(screen.getByText('10,000 원')).toBeInTheDocument();
+    expect(screen.getByText(/29/)).toBeInTheDocument();
+    expect(screen.getByText(/5,000/)).toBeInTheDocument();
+    expect(screen.getByText(/10,000/)).toBeInTheDocument();
   });
 });

--- a/src/pages/Profile/User.jsx
+++ b/src/pages/Profile/User.jsx
@@ -10,14 +10,14 @@ export default function User({ profile }) {
       <dd>이름:</dd>
       <dt>{name}</dt>
       <dd>나이:</dd>
-      <dt>{age}</dt>
-      <dd>월 저축 금액(만원):</dd>
+      <dt>{`${age} 살`}</dt>
+      <dd>월 저축 금액:</dd>
       <dt>
-        {`${monthlySavings.toLocaleString()} 원`}
+        {`${monthlySavings.toLocaleString()} 만원`}
       </dt>
-      <dd>현재 은행 잔액(만원):</dd>
+      <dd>현재 은행 잔액:</dd>
       <dt>
-        {`${currentBalance.toLocaleString()} 원`}
+        {`${currentBalance.toLocaleString()} 만원`}
       </dt>
     </dl>
   );

--- a/src/pages/Profile/User.test.jsx
+++ b/src/pages/Profile/User.test.jsx
@@ -19,8 +19,8 @@ describe('User', () => {
     />);
 
     expect(screen.getByText('신형탁')).toBeInTheDocument();
-    expect(screen.getByText('29')).toBeInTheDocument();
-    expect(screen.getByText('5,000 원')).toBeInTheDocument();
-    expect(screen.getByText('10,000 원')).toBeInTheDocument();
+    expect(screen.getByText(/29/)).toBeInTheDocument();
+    expect(screen.getByText(/5,000/)).toBeInTheDocument();
+    expect(screen.getByText(/10,000/)).toBeInTheDocument();
   });
 });

--- a/src/pages/Result/ApartmentDetail.jsx
+++ b/src/pages/Result/ApartmentDetail.jsx
@@ -25,7 +25,7 @@ export default function ApartmentDetail({ apartment }) {
 
         <dd>거래금액:</dd>
         <dt>
-          {`${price.toLocaleString()} 원`}
+          {`${price.toLocaleString()} 만원`}
         </dt>
 
         <dd>매매일자:</dd>

--- a/src/pages/Result/ApartmentDetail.test.jsx
+++ b/src/pages/Result/ApartmentDetail.test.jsx
@@ -19,7 +19,7 @@ describe('ApartmentDetail', () => {
 
     expect(screen.getByText('아크로리버파크')).toBeInTheDocument();
     expect(screen.getByText('129.92')).toBeInTheDocument();
-    expect(screen.getByText('470,000 원')).toBeInTheDocument();
+    expect(screen.getByText(/470,000/)).toBeInTheDocument();
     expect(screen.getByText('2021-03')).toBeInTheDocument();
     expect(screen.getByText('반포동')).toBeInTheDocument();
     expect(screen.getByText('1')).toBeInTheDocument();

--- a/src/pages/Result/Estimation.jsx
+++ b/src/pages/Result/Estimation.jsx
@@ -5,17 +5,17 @@ export default function Estimation({ estimation }) {
 
   return (
     <dl>
-      <dd>필요 금액(만원):</dd>
+      <dd>필요 금액:</dd>
       <dt>
-        {`${price.toLocaleString()} 원`}
+        {`${price.toLocaleString()} 만원`}
       </dt>
-      <dd>소요 기간(년):</dd>
+      <dd>소요 기간:</dd>
       <dt>
-        {year.toLocaleString()}
+        {`${year.toLocaleString()} 년`}
       </dt>
       <dd>구매 할 때 나이: </dd>
       <dt>
-        {age.toLocaleString()}
+        {`${age.toLocaleString()} 살`}
       </dt>
     </dl>
   );

--- a/src/pages/Result/Estimation.test.jsx
+++ b/src/pages/Result/Estimation.test.jsx
@@ -14,8 +14,8 @@ describe('Estimation', () => {
   it('renders Estimation', () => {
     render(<Estimation estimation={estimation} />);
 
-    expect(screen.getByText('460,000 원')).toBeInTheDocument();
-    expect(screen.getByText('94')).toBeInTheDocument();
-    expect(screen.getByText('123')).toBeInTheDocument();
+    expect(screen.getByText(/460,000/)).toBeInTheDocument();
+    expect(screen.getByText(/94/)).toBeInTheDocument();
+    expect(screen.getByText(/123/)).toBeInTheDocument();
   });
 });

--- a/src/pages/Result/Result.test.jsx
+++ b/src/pages/Result/Result.test.jsx
@@ -19,7 +19,7 @@ describe('Result', () => {
   const profile = {
     isNew: false,
     name: '신형탁',
-    age: '29',
+    age: 29,
     monthlySavings: 5000,
     currentBalance: 10000,
   };
@@ -63,7 +63,7 @@ describe('Result', () => {
 
       expect(screen.getByText('아크로리버파크')).toBeInTheDocument();
       expect(screen.getByText('129.92')).toBeInTheDocument();
-      expect(screen.getByText('470,000 원')).toBeInTheDocument();
+      expect(screen.getByText(/470,000/)).toBeInTheDocument();
       expect(screen.getByText('2021-03')).toBeInTheDocument();
       expect(screen.getByText('반포동')).toBeInTheDocument();
       expect(screen.getByText('1')).toBeInTheDocument();
@@ -73,17 +73,17 @@ describe('Result', () => {
       renderResult();
 
       expect(screen.getByText('신형탁')).toBeInTheDocument();
-      expect(screen.getByText('29')).toBeInTheDocument();
-      expect(screen.getByText('5,000 원')).toBeInTheDocument();
-      expect(screen.getByText('10,000 원')).toBeInTheDocument();
+      expect(screen.getAllByText(/29/)[1]).toBeInTheDocument();
+      expect(screen.getByText(/5,000/)).toBeInTheDocument();
+      expect(screen.getByText(/10,000/)).toBeInTheDocument();
     });
 
     it('renders Esitmation', () => {
       renderResult();
 
-      expect(screen.getByText('460,000 원')).toBeInTheDocument();
-      expect(screen.getByText('94')).toBeInTheDocument();
-      expect(screen.getByText('123')).toBeInTheDocument();
+      expect(screen.getByText(/460,000/)).toBeInTheDocument();
+      expect(screen.getByText(/94/)).toBeInTheDocument();
+      expect(screen.getByText(/123/)).toBeInTheDocument();
     });
 
     it("calls handleClick upon clicking '뒤로가기'", () => {

--- a/src/pages/Result/ResultContainer.test.jsx
+++ b/src/pages/Result/ResultContainer.test.jsx
@@ -57,7 +57,7 @@ describe('ResultContainer', () => {
 
       expect(screen.getByText('아크로리버파크')).toBeInTheDocument();
       expect(screen.getByText('129.92')).toBeInTheDocument();
-      expect(screen.getByText('470,000 원')).toBeInTheDocument();
+      expect(screen.getByText(/470,000/)).toBeInTheDocument();
       expect(screen.getByText('2021-03')).toBeInTheDocument();
       expect(screen.getByText('반포동')).toBeInTheDocument();
       expect(screen.getByText('1')).toBeInTheDocument();


### PR DESCRIPTION
- Various Circumstances, such as design, locale, etc., can change unit dependency often.
- Testing a fixed unit of number is a potential cause to sabotage the entire process.

For instance, 
when foreign users who can not read Korean visit the site,
'won' must be shown instead of '원.'

![image](https://user-images.githubusercontent.com/77006427/114486816-7edeac00-9c49-11eb-9e12-e9d3261a4d8e.png)
