### PR TITLE
✏️typo: Fix Apartment type '강낭' to '강남'

### DIFF
--- a/src/pages/Apartment/ApartmentNavigation.jsx
+++ b/src/pages/Apartment/ApartmentNavigation.jsx
@@ -83,7 +83,7 @@ export default function ApartmentNavigation({ apartmentCategory, onClick }) {
         >
           <LinkField
             url="/apartments/commute_gangnam"
-            title="#강낭 출퇴근 편리"
+            title="#강남 출퇴근 편리"
             onClick={onClick}
           />
         </Item>


### PR DESCRIPTION
Incorrect notation on Gangnam District.