### PR TITLE
💄UI/UX: Enter Profile form when user selects apartment

### DIFF
--- a/src/pages/Apartment/Apartments.jsx
+++ b/src/pages/Apartment/Apartments.jsx
@@ -41,7 +41,12 @@ const Article = styled.article({
   },
 });
 
-export default function Apartments({ apartments, onClick, changeApartment }) {
+export default function Apartments({
+  profile,
+  apartments,
+  onClick,
+  changeApartment,
+}) {
   if (!apartments.length) {
     return (
       <p>loading</p>
@@ -54,7 +59,7 @@ export default function Apartments({ apartments, onClick, changeApartment }) {
         <Article key={apartment.name}>
           <Apartment apartment={apartment} />
           <LinkField
-            url="/result"
+            url={profile?.isNew ? '/profile' : '/result'}
             title="구매 해보기"
             onClick={onClick}
             apartment={apartment}

--- a/src/pages/Apartment/ApartmentsContainer.jsx
+++ b/src/pages/Apartment/ApartmentsContainer.jsx
@@ -15,6 +15,7 @@ export default function ApartmentContainer({ apartmentCategory, onClick }) {
     dispatch(loadApartments(apartmentCategory));
   }, [apartmentCategory]);
 
+  const profile = useSelector(get('userFields'));
   const apartments = useSelector(get('apartments'));
 
   function changeApartment(apartment) {
@@ -24,6 +25,7 @@ export default function ApartmentContainer({ apartmentCategory, onClick }) {
   return (
     <>
       <Apartments
+        profile={profile}
         apartments={apartments}
         onClick={onClick}
         changeApartment={changeApartment}

--- a/src/pages/Apartment/ApartmentsContainer.test.jsx
+++ b/src/pages/Apartment/ApartmentsContainer.test.jsx
@@ -1,13 +1,42 @@
 import React from 'react';
 
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 import { useDispatch, useSelector } from 'react-redux';
+
+import given from 'given2';
 
 import ApartmentsContainer from './ApartmentsContainer';
 
 describe('ApartmentsContainer', () => {
   const dispatch = jest.fn();
+
+  const handleClick = jest.fn();
+
+  const newUser = {
+    isNew: true,
+    name: '',
+    age: '',
+    monthlySavings: '',
+    currentBalance: '',
+  };
+
+  const profile = {
+    isNew: false,
+    name: 'tak',
+    age: '29',
+    monthlySavings: 5000,
+    currentBalance: 10000,
+  };
+
+  function renderApartmentContainer() {
+    return render((
+      <ApartmentsContainer
+        apartmentCategory="riverside"
+        onClick={handleClick}
+      />
+    ));
+  }
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -15,6 +44,7 @@ describe('ApartmentsContainer', () => {
     useDispatch.mockImplementation(() => dispatch);
 
     useSelector.mockImplementation((selector) => selector({
+      userFields: given.profile,
       apartments: [
         {
           name: '아크로리버파크',
@@ -35,13 +65,50 @@ describe('ApartmentsContainer', () => {
   });
 
   it('renders Apartment Page', () => {
-    render((
-      <ApartmentsContainer apartmentCategory="riverside" />
-    ));
+    renderApartmentContainer();
 
     expect(screen.getByText('아크로리버파크')).toBeInTheDocument();
     expect(screen.getByText('서울')).toBeInTheDocument();
+  });
 
-    expect(dispatch).toBeCalled();
+  it('executes diaptch setApartment', () => {
+    renderApartmentContainer();
+
+    fireEvent.click(screen.getAllByText(/구매/)[0]);
+
+    expect(dispatch).toBeCalledWith({
+      type: 'applications/setApartment',
+      payload: {
+        name: '아크로리버파크',
+        date: '2021-03',
+        size: '129.92',
+        price: 470000,
+        lotNumber: 1,
+      },
+    });
+  });
+
+  context('without profile', () => {
+    given('profile', () => (newUser));
+
+    it('navigates user to profile page', () => {
+      renderApartmentContainer();
+
+      fireEvent.click(screen.getAllByText(/구매/)[0]);
+
+      expect(handleClick).toBeCalledWith({ url: '/profile' });
+    });
+  });
+
+  context('with profile', () => {
+    given('profile', () => (profile));
+
+    it('navigates user to profile page', () => {
+      renderApartmentContainer();
+
+      fireEvent.click(screen.getAllByText(/구매/)[0]);
+
+      expect(handleClick).toBeCalledWith({ url: '/result' });
+    });
   });
 });

--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -6,64 +6,19 @@ import {
   colors,
   fontWeights,
   borderRadius,
-  shadows,
 } from '../../designSystem';
 
 import { LinkField } from '../../commons/Fields';
 
-import Greet from './Greet';
-
 const HomeLayout = styled.section({
   display: 'flex',
   flexDirection: 'column',
-  justifyContent: 'space-between',
-
-  '& article:first-of-type': {
-    position: 'relative',
-
-    '& ::before': {
-      content: '""',
-
-      display: 'block',
-      position: 'absolute',
-      inset: '0',
-
-      backgroundImage: 'url("https://images.unsplash.com/photo-1554224155-6726b3ff858f?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1472&q=80")',
-      backgroundRepeat: 'no-repeat',
-      backgroundSize: 'cover',
-
-      opacity: '0.27',
-      borderRadius: borderRadius.box,
-      zIndex: '-1',
-    },
-  },
-
-  '& article:last-of-type': {
-    position: 'relative',
-    marginTop: '4.5rem',
-
-    '& ::before': {
-      content: '""',
-
-      display: 'block',
-      position: 'absolute',
-      inset: '0',
-
-      backgroundImage: 'url("http://webzine.seoulmetro.co.kr/images/0969565312_041/%EC%9E%A0%EC%8B%A4%EC%B2%A0%EA%B5%903.JPG")',
-      backgroundRepeat: 'no-repeat',
-      backgroundSize: 'cover',
-
-      opacity: '0.27',
-      borderRadius: borderRadius.box,
-      zIndex: '-1',
-    },
-  },
 });
 
 const Heading = styled.h2({
   display: 'flex',
   alignItems: 'center',
-  marginBottom: '2.5rem',
+  marginBottom: '2rem',
 
   color: colors.bluishGray,
   fontSize: '1.5rem',
@@ -73,34 +28,34 @@ const Heading = styled.h2({
 
 const Article = styled.article({
   maxWidth: '639px',
-  minHeight: '200px',
 
   display: 'flex',
   flexDirection: 'column',
-  justifyContent: 'space-between',
   alignItems: 'center',
-  textAlign: 'center',
 
   color: colors.white,
 
-  borderRadius: borderRadius.box,
-  boxShadow: shadows.article,
-
   '& p': {
-    marginTop: '-2rem',
+    padding: '2rem',
 
     color: colors.bluishGray,
-    fontsize: '3rem',
+    fontSize: '1.2rem',
     fontWeight: fontWeights.bold,
-    lineHeight: '2',
   },
 
   '& div': {
-    marginBottom: '-0.7rem',
+    padding: '2rem',
+  },
+
+  '& img': {
+    width: '100%',
+    objectFit: 'cover',
+
+    borderRadius: borderRadius.box,
   },
 });
 
-export default function Home({ profile, onClick }) {
+export default function Home({ onClick }) {
   return (
     <HomeLayout>
       <Heading>
@@ -112,18 +67,13 @@ export default function Home({ profile, onClick }) {
       </Heading>
 
       <Article>
-        {profile && (
-          <Greet
-            profile={profile}
-            onClick={onClick}
-          />
-        )}
-      </Article>
-
-      <Article>
         <p>
           한강 뷰 아파트에 살아볼려면?
         </p>
+        <img
+          src="http://webzine.seoulmetro.co.kr/images/0969565312_041/%EC%9E%A0%EC%8B%A4%EC%B2%A0%EA%B5%903.JPG"
+          alt="hanriver"
+        />
         <LinkField
           url="/apartments/riverside"
           title="알아 보러가기"

--- a/src/pages/Home/HomeContainer.jsx
+++ b/src/pages/Home/HomeContainer.jsx
@@ -1,17 +1,10 @@
 import React from 'react';
 
-import { useSelector } from 'react-redux';
-
-import { get } from '../../utils/utils';
-
 import Home from './Home';
 
 export default function HomeContainer({ onClick }) {
-  const profile = useSelector(get('userFields'));
-
   return (
     <Home
-      profile={profile}
       onClick={onClick}
     />
   );

--- a/src/pages/Home/HomeContainer.test.jsx
+++ b/src/pages/Home/HomeContainer.test.jsx
@@ -1,44 +1,21 @@
 import React from 'react';
 
-import { render, screen } from '@testing-library/react';
-
-import { useSelector } from 'react-redux';
-
-import given from 'given2';
-
-import { initialUserField } from '../../fixtures/initials';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 import HomeContainer from './HomeContainer';
 
 describe('HomeContainer', () => {
-  beforeEach(() => {
-    useSelector.mockImplementation((selector) => selector({
-      userFields: given.userFields,
-    }));
-  });
+  const handleClick = jest.fn();
 
-  context('without profile', () => {
-    given('userFields', () => initialUserField);
+  it('navgiates user to apartment page', () => {
+    render((
+      <HomeContainer onClick={handleClick} />
+    ));
 
-    it('renders Home Page', () => {
-      render(<HomeContainer />);
-
-      expect(screen.getByText(/XXX님/)).toBeInTheDocument();
-    });
-  });
-
-  context('with profile', () => {
-    given('userFields', () => ({
-      isNew: false,
-      name: '신형탁',
-      age: '29',
-      monthlySavings: 5000,
-      currentBalance: 10000,
+    fireEvent.click(screen.getByRole('link', {
+      name: /알아/,
     }));
 
-    it('renders user name', () => {
-      render(<HomeContainer />);
-      expect(screen.getByText(/신형탁/)).toBeInTheDocument();
-    });
+    expect(handleClick).toBeCalledWith({ url: '/apartments/riverside' });
   });
 });

--- a/src/pages/NewProfile/NewProfileContainer.jsx
+++ b/src/pages/NewProfile/NewProfileContainer.jsx
@@ -24,9 +24,7 @@ export default function NewProfileContainer({ onClick }) {
       dispatch(setUserFields(profile));
     }
 
-    onClick({
-      url: profile?.isNew ? '/apartments/riverside' : '/result',
-    });
+    onClick({ url: '/result' });
   });
 
   return (

--- a/src/pages/NewProfile/NewProfileContainer.test.jsx
+++ b/src/pages/NewProfile/NewProfileContainer.test.jsx
@@ -8,21 +8,12 @@ import {
 
 import { useDispatch, useSelector } from 'react-redux';
 
-import given from 'given2';
-
 import NewProfileContainer from './NewProfileContainer';
 
 describe('NewProfileContainer', () => {
-  const handleClick = jest.fn();
   const dispatch = jest.fn();
 
-  const newUser = {
-    isNew: true,
-    name: '',
-    age: '',
-    monthlySavings: '',
-    currentBalance: '',
-  };
+  const handleClick = jest.fn();
 
   const profile = {
     isNew: false,
@@ -38,15 +29,13 @@ describe('NewProfileContainer', () => {
     />
   ));
 
-  given('profile', () => (profile));
-
   beforeEach(() => {
     jest.clearAllMocks();
 
     useDispatch.mockImplementation(() => dispatch);
 
     useSelector.mockImplementation((selecotr) => selecotr({
-      userFields: given.profile,
+      userFields: profile,
     }));
   });
 
@@ -78,29 +67,13 @@ describe('NewProfileContainer', () => {
     });
   });
 
-  context('when user is not new', () => {
-    it('navigates user to apartment page', () => {
-      renderNewProfileContainer();
+  it('navigates user to result page', () => {
+    renderNewProfileContainer();
 
-      fireEvent.submit(screen.getByRole('button', {
-        value: '저장',
-      }));
+    fireEvent.submit(screen.getByRole('button', {
+      value: '저장',
+    }));
 
-      expect(handleClick).toBeCalledWith({ url: '/result' });
-    });
-  });
-
-  context('when user is new', () => {
-    given('profile', () => (newUser));
-
-    it('navigates user to apartment page', () => {
-      renderNewProfileContainer();
-
-      fireEvent.submit(screen.getByRole('button', {
-        value: '저장',
-      }));
-
-      expect(handleClick).toBeCalledWith({ url: '/apartments/riverside' });
-    });
+    expect(handleClick).toBeCalledWith({ url: '/result' });
   });
 });


### PR DESCRIPTION
#102 

Not to let the user think twice about which one to choose on the home page.

Users can directly view a list of the apartments, whether they have profiles or not.

This would encourage users to look over the apartments at first.

If they are curious how much more money they need to buy the apartment.  

![navigate_profile](https://user-images.githubusercontent.com/77006427/115417481-9d3d3c80-a233-11eb-8099-c3dc1290c45b.gif)
