### PR TITLE
🐛fix: Navigate user to apartment page upon clicking go back

### DIFF
--- a/src/pages/Result/Result.jsx
+++ b/src/pages/Result/Result.jsx
@@ -76,7 +76,6 @@ export default function Result({
   apartment,
   estimation,
   onClick,
-  goBack,
 }) {
   if (profile.isNew) {
     return (
@@ -99,7 +98,7 @@ export default function Result({
         <LinkField
           url="/apartments"
           title="뒤로가기"
-          onClick={goBack}
+          onClick={() => onClick({ url: '/apartments/riverside' })}
         />
       </Back>
 

--- a/src/pages/Result/Result.test.jsx
+++ b/src/pages/Result/Result.test.jsx
@@ -82,16 +82,6 @@ describe('Result', () => {
 
       expect(screen.getByText(/Copy/)).toBeInTheDocument();
     });
-
-    it("calls handleClick upon clicking '뒤로가기'", () => {
-      renderResult();
-
-      fireEvent.click(screen.getByRole('link', {
-        name: '뒤로가기',
-      }));
-
-      expect(goBack).toBeCalledWith({ url: '/apartments' });
-    });
   });
 
   context('without profile', () => {

--- a/src/pages/Result/ResultContainer.jsx
+++ b/src/pages/Result/ResultContainer.jsx
@@ -8,7 +8,7 @@ import { get } from '../../utils/utils';
 
 import Result from './Result';
 
-export default function ResultContainer({ onClick, goBack }) {
+export default function ResultContainer({ onClick }) {
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -26,7 +26,6 @@ export default function ResultContainer({ onClick, goBack }) {
         apartment={apartment}
         estimation={esitamtion}
         onClick={onClick}
-        goBack={goBack}
       />
     </>
   );

--- a/src/pages/Result/ResultContainer.test.jsx
+++ b/src/pages/Result/ResultContainer.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 import { useSelector, useDispatch } from 'react-redux';
 
@@ -12,6 +12,8 @@ import ResultContainer from './ResultContainer';
 
 describe('ResultContainer', () => {
   const dispatch = jest.fn();
+
+  const handleClick = jest.fn();
 
   const profile = {
     isNew: false,
@@ -36,6 +38,12 @@ describe('ResultContainer', () => {
     age: '123',
   };
 
+  function renderResultContainer() {
+    return render((
+      <ResultContainer onClick={handleClick} />
+    ));
+  }
+
   beforeEach(() => {
     jest.clearAllMocks();
 
@@ -53,7 +61,7 @@ describe('ResultContainer', () => {
     given('estimation', () => estimation);
 
     it('renders result page', () => {
-      render(<ResultContainer />);
+      renderResultContainer();
 
       expect(screen.getByText('아크로리버파크')).toBeInTheDocument();
       expect(screen.getByText('129.92')).toBeInTheDocument();
@@ -61,15 +69,32 @@ describe('ResultContainer', () => {
       expect(screen.getByText('2021-03')).toBeInTheDocument();
       expect(screen.getByText('반포동')).toBeInTheDocument();
       expect(screen.getByText('1')).toBeInTheDocument();
+    });
 
-      expect(dispatch).toBeCalled();
+    it('executes dispatch setEstimation on loading Result Page', () => {
+      renderResultContainer();
+
+      expect(dispatch).toBeCalledWith({
+        type: 'applications/setEstimation',
+      });
+    });
+
+    it('navigates User to apartment page when clicking go back button', () => {
+      renderResultContainer();
+
+      fireEvent.click(screen.getByRole('link', {
+        name: /뒤로/,
+      }));
+
+      expect(handleClick).toBeCalledWith({ url: '/apartments/riverside' });
     });
   });
 
   context('without profile', () => {
     given('profile', () => initialUserField);
+
     it('renders link for user to fill up the profile', () => {
-      render(<ResultContainer />);
+      renderResultContainer();
 
       expect(screen.getByText(/정보/)).toBeInTheDocument();
 

--- a/src/pages/Result/ResultPage.jsx
+++ b/src/pages/Result/ResultPage.jsx
@@ -7,7 +7,7 @@ import { colors, fontWeights } from '../../designSystem';
 import ResultContainer from './ResultContainer';
 
 export default function ResultPage() {
-  const { goTo, goBack } = useLink();
+  const { goTo } = useLink();
 
   return (
     <>
@@ -26,7 +26,6 @@ export default function ResultPage() {
       </h2>
       <ResultContainer
         onClick={goTo}
-        goBack={goBack}
       />
     </>
   );


### PR DESCRIPTION
`history.goback` navigates the user to the previous stack of the history. (pop-up)

Once the user has finished editing their profile form, return to the result page.

 Afterward, clicking the 'Go back' button redirects the user to the profile form again
 due to the previous stack is 'Profile Page.'  

See Also:
- https://reactrouter.com/web/api/history

![fix_goback](https://user-images.githubusercontent.com/77006427/115423792-14c19a80-a239-11eb-92d5-1fad5d9cc1f9.gif)
