### PR TITLE
💄UI/UX [#100]: Format Price with number and lingual

### DIFF
--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -169,10 +169,6 @@ describe('App', () => {
       renderApp({ path: '/result' });
 
       expect(screen.getByText(/선택/)).toBeInTheDocument();
-
-      expect(screen.getByText('아크로리버파크')).toBeInTheDocument();
-      expect(screen.getByText('129.92')).toBeInTheDocument();
-      expect(screen.getByText(/470,000/)).toBeInTheDocument();
     });
   });
 

--- a/src/pages/NewProfile/NewProfile.test.jsx
+++ b/src/pages/NewProfile/NewProfile.test.jsx
@@ -60,7 +60,7 @@ describe('NewProfile', () => {
   it('renders price in Korean', () => {
     renderNewProfile(profile);
 
-    expect(screen.getByText('오천만 원')).toBeInTheDocument();
-    expect(screen.getByText('일억 원')).toBeInTheDocument();
+    expect(screen.getByText('5,000만 원')).toBeInTheDocument();
+    expect(screen.getByText('1억 원')).toBeInTheDocument();
   });
 });

--- a/src/pages/Result/ApartmentDetail.jsx
+++ b/src/pages/Result/ApartmentDetail.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 
 import styled from '@emotion/styled';
 
+import { translateNumericToKor } from '../../utils/utils';
+
 import {
   Currency,
   District,
@@ -57,7 +59,7 @@ export default function ApartmentDetail({ apartment }) {
             거래금액:
           </dd>
           <dt>
-            {`${price.toLocaleString()} 만원`}
+            {`${translateNumericToKor(price)} 원`}
           </dt>
         </Item>
 

--- a/src/pages/Result/ApartmentDetail.test.jsx
+++ b/src/pages/Result/ApartmentDetail.test.jsx
@@ -19,7 +19,7 @@ describe('ApartmentDetail', () => {
 
     expect(screen.getByText('아크로리버파크')).toBeInTheDocument();
     expect(screen.getByText('129.92')).toBeInTheDocument();
-    expect(screen.getByText(/470,000/)).toBeInTheDocument();
+    expect(screen.getByText(/47억/)).toBeInTheDocument();
     expect(screen.getByText('2021-03')).toBeInTheDocument();
     expect(screen.getByText('반포동')).toBeInTheDocument();
     expect(screen.getByText('1')).toBeInTheDocument();

--- a/src/pages/Result/Estimation.jsx
+++ b/src/pages/Result/Estimation.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 
 import styled from '@emotion/styled';
 
+import { translateNumericToKor } from '../../utils/utils';
+
 import {
   Currency,
   Calendar,
@@ -43,7 +45,7 @@ export default function Estimation({ profile, estimation }) {
         </Header>
         <span>
           <Currency />
-          {`${price.toLocaleString()} 만원`}
+          {`${translateNumericToKor(price)} 원`}
         </span>
       </Item>
 

--- a/src/pages/Result/Estimation.test.jsx
+++ b/src/pages/Result/Estimation.test.jsx
@@ -26,7 +26,7 @@ describe('Estimation', () => {
         estimation={estimation}
       />));
 
-    expect(screen.getByText(/460,000/)).toBeInTheDocument();
+    expect(screen.getByText(/46억/)).toBeInTheDocument();
     expect(screen.getByText(/94/)).toBeInTheDocument();
     expect(screen.getByText(/123/)).toBeInTheDocument();
   });

--- a/src/pages/Result/Result.test.jsx
+++ b/src/pages/Result/Result.test.jsx
@@ -63,7 +63,7 @@ describe('Result', () => {
 
       expect(screen.getByText('아크로리버파크')).toBeInTheDocument();
       expect(screen.getByText('129.92')).toBeInTheDocument();
-      expect(screen.getByText(/470,000/)).toBeInTheDocument();
+      expect(screen.getByText(/47억/)).toBeInTheDocument();
       expect(screen.getByText('2021-03')).toBeInTheDocument();
       expect(screen.getByText('반포동')).toBeInTheDocument();
       expect(screen.getByText('1')).toBeInTheDocument();
@@ -72,7 +72,7 @@ describe('Result', () => {
     it('renders Esitmation', () => {
       renderResult();
 
-      expect(screen.getByText(/460,000/)).toBeInTheDocument();
+      expect(screen.getByText(/46억/)).toBeInTheDocument();
       expect(screen.getByText(/94/)).toBeInTheDocument();
       expect(screen.getByText(/123/)).toBeInTheDocument();
     });

--- a/src/pages/Result/ResultContainer.test.jsx
+++ b/src/pages/Result/ResultContainer.test.jsx
@@ -60,17 +60,6 @@ describe('ResultContainer', () => {
     given('profile', () => profile);
     given('estimation', () => estimation);
 
-    it('renders result page', () => {
-      renderResultContainer();
-
-      expect(screen.getByText('아크로리버파크')).toBeInTheDocument();
-      expect(screen.getByText('129.92')).toBeInTheDocument();
-      expect(screen.getByText(/470,000/)).toBeInTheDocument();
-      expect(screen.getByText('2021-03')).toBeInTheDocument();
-      expect(screen.getByText('반포동')).toBeInTheDocument();
-      expect(screen.getByText('1')).toBeInTheDocument();
-    });
-
     it('executes dispatch setEstimation on loading Result Page', () => {
       renderResultContainer();
 

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,4 +1,4 @@
-import { numToKorean } from 'num-to-korean';
+import { numToKorean, FormatOptions } from 'num-to-korean';
 
 export function get(key) {
   return (obj) => obj[key];
@@ -45,5 +45,5 @@ export function convertToKRW(price) {
 }
 
 export function translateNumericToKor(price) {
-  return numToKorean(parseInt(price, 10) * 10000);
+  return numToKorean(parseInt(price, 10) * 10000, FormatOptions.MIXED);
 }

--- a/src/utils/utils.test.js
+++ b/src/utils/utils.test.js
@@ -72,5 +72,8 @@ test('convertToKRW', () => {
 test('translateNumericToKor', () => {
   const text = '5000';
 
-  expect(translateNumericToKor(text)).toBe('오천만');
+  expect(translateNumericToKor(text)).toBe('5,000만');
+
+  expect(translateNumericToKor(text)).not.toBe('오천만');
+  expect(translateNumericToKor(text)).not.toBe('5000만');
 });


### PR DESCRIPTION
Issue #100

The Price notation with '10,000만 원' triggered users
an extra counting process to interpret how much money it is really.

For intuitive, showing the price as '1억 원' is much easier for them
to recognize it at a glance.

![image](https://user-images.githubusercontent.com/77006427/115807812-43e82f80-a424-11eb-8541-5078c57f2938.png)
